### PR TITLE
Add signup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '2.3.1'
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 
 gem 'devise', '~> 4.2.0'
+gem 'devise_token_auth', '~> 0.1.39'
 gem 'haml', '~> 4.0.6'
 gem 'puma', '~> 3.0'
 gem 'rack-cors', '~> 0.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,9 @@ GEM
       railties (>= 4.1.0, < 5.1)
       responders
       warden (~> 1.2.3)
+    devise_token_auth (0.1.39)
+      devise (> 3.5.2, <= 4.2)
+      rails (< 6)
     diff-lcs (1.2.5)
     equalizer (0.0.11)
     erubis (2.7.0)
@@ -251,6 +254,7 @@ DEPENDENCIES
   brakeman (~> 3.4.0)
   database_cleaner (~> 1.4.1)
   devise (~> 4.2.0)
+  devise_token_auth (~> 0.1.39)
   factory_girl_rails (~> 4.5.0)
   faker (~> 1.4.3)
   haml (~> 4.0.6)

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,39 @@
+# encoding: utf-8
+
+module Api
+  module V1
+    class ApiController < ApplicationController
+      protect_from_forgery with: :null_session
+      include DeviseTokenAuth::Concerns::SetUserByToken
+
+      layout false
+      respond_to :json
+
+      rescue_from ActiveRecord::RecordNotFound,        with: :render_not_found
+      rescue_from ActiveRecord::RecordInvalid,         with: :render_record_invalid
+      rescue_from ActionController::RoutingError,      with: :render_not_found
+      rescue_from ActionController::UnknownController, with: :render_not_found
+      rescue_from AbstractController::ActionNotFound,  with: :render_not_found
+      rescue_from PermissionsHelper::ForbiddenAccess,  with: :render_forbidden_access
+
+      def status
+        render json: { online: true }
+      end
+
+      def render_forbidden_access(exception)
+        logger.info(exception) # for logging
+        render json: { error: 'Not Authorized' }, status: :forbidden
+      end
+
+      def render_not_found(exception)
+        logger.info(exception) # for logging
+        render json: { error: "Couldn't find the record" }, status: :not_found
+      end
+
+      def render_record_invalid(exception)
+        logger.info(exception) # for logging
+        render json: { errors: exception.record.errors.as_json }, status: :bad_request
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+
+module Api
+  module V1
+    class RegistrationsController < DeviseTokenAuth::RegistrationsController
+      def sign_up_params
+        params.require(:user).permit(:email, :password, :password_confirmation, :username)
+      end
+
+      def render_create_success
+        render json: resource_data
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,11 +18,15 @@
 #  username               :string           default("")
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  provider               :string           default("email"), not null
+#  uid                    :string           default(""), not null
+#  tokens                 :json
 #
 # Indexes
 #
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
 #
 
 class User < ApplicationRecord
@@ -30,6 +34,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+  include DeviseTokenAuth::Concerns::User
 
   def full_name
     return username unless first_name.present?

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,3 @@
+DeviseTokenAuth.setup do |config|
+  config.default_confirm_success_url = '/'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
-  devise_for :users
-  root to: 'home#index'
+  mount_devise_token_auth_for 'User', at: '/api/v1/users', controllers: {
+    registrations:  'api/v1/registrations'
+  }
+  root 'api/v1/api#status'
 end

--- a/db/migrate/20161017183759_add_devise_token_auth_fields_users.rb
+++ b/db/migrate/20161017183759_add_devise_token_auth_fields_users.rb
@@ -1,0 +1,9 @@
+class AddDeviseTokenAuthFieldsUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :provider, :string, null: false, default: 'email'
+    add_column :users, :uid, :string, null: false, default: ''
+    add_column :users, :tokens, :json
+
+    add_index :users, [:uid, :provider], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161011151353) do
+ActiveRecord::Schema.define(version: 20161017183759) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",      null: false
+    t.string   "encrypted_password",     default: "",      null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,       null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
@@ -29,10 +29,14 @@ ActiveRecord::Schema.define(version: 20161011151353) do
     t.string   "first_name",             default: ""
     t.string   "last_name",              default: ""
     t.string   "username",               default: ""
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+    t.string   "provider",               default: "email", null: false
+    t.string   "uid",                    default: "",      null: false
+    t.json     "tokens"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true, using: :btree
   end
 
 end

--- a/spec/controllers/api/v1/registrations_controller_spec.rb
+++ b/spec/controllers/api/v1/registrations_controller_spec.rb
@@ -1,0 +1,93 @@
+# encoding: utf-8
+
+require 'rails_helper'
+
+describe Api::V1::RegistrationsController do
+  render_views
+
+  let!(:user) { create(:user) }
+  let(:failed_response) { 422 }
+
+  describe 'POST create' do
+    let(:username)              { 'test' }
+    let(:email)                 { 'test@test.com' }
+    let(:password)              { '12345678' }
+    let(:password_confirmation) { '12345678' }
+
+    let(:attrs) do
+      {
+        username: username,
+        email: email,
+        password: password,
+        password_confirmation: password_confirmation
+      }
+    end
+
+    it 'returns a successful response' do
+      post :create, params: { user: attrs, format: 'json' }
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'creates the user' do
+      post :create, params: { user: attrs, format: 'json' }
+
+      new_user = User.find_by_email(email)
+      expect(new_user).to_not be_nil
+    end
+
+    context 'when the email is not correct' do
+      let(:email) { 'invalid_email' }
+
+      it 'does not create a user' do
+        expect do
+          post :create, params: { user: attrs, format: 'json' }
+        end.not_to change { User.count }
+      end
+
+      it 'does not return a successful response' do
+        post :create, params: { user: attrs, format: 'json' }
+
+        expect(response.response_code).to eq(failed_response)
+      end
+    end
+
+    context 'when the password is incorrect' do
+      let(:password)              { 'short' }
+      let(:password_confirmation) { 'short' }
+
+      let(:new_user)              { User.find_by_email(email) }
+
+      it 'does not create a user' do
+        post :create, params: { user: attrs, format: 'json' }
+
+        expect(new_user).to be_nil
+      end
+
+      it 'does not return a successful response' do
+        post :create, params: { user: attrs, format: 'json' }
+
+        expect(response.response_code).to eq(failed_response)
+      end
+    end
+
+    context 'when passwords don\'t match' do
+      let(:password)              { 'shouldmatch' }
+      let(:password_confirmation) { 'dontmatch' }
+
+      let(:new_user)              { User.find_by_email(email) }
+
+      it 'does not create a user' do
+        post :create, params: { user: attrs, format: 'json' }
+
+        expect(new_user).to be_nil
+      end
+
+      it 'does not return a successful response' do
+        post :create, params: { user: attrs, format: 'json' }
+
+        expect(response.response_code).to eq(failed_response)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,7 +29,7 @@
 #  index_users_on_uid_and_provider      (uid,provider) UNIQUE
 #
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe User do
   context 'when was created with regular login' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,12 +20,19 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.order = 'random'
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
   config.include FactoryGirl::Syntax::Methods
-
-  config.before :each do |example_group|
+  
+  config.before :each do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.start
     ActionMailer::Base.deliveries.clear
+  end
+
+  config.before(:each, type: :controller) do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
   end
 
   config.after do


### PR DESCRIPTION
This PR includes:
- Added [devise_token_auth](https://github.com/lynndylanhurley/devise_token_auth) instead of the previous devise api gem [simple_token_authentication](https://github.com/gonzalo-bulnes/simple_token_authentication). The second one has some issues like the persisted cookie if you use REST client like Postman
- Added api controller, copied from the [previous api base](https://github.com/toptierlabs/rails_api_base/blob/master/app/controllers/api/v1/api_controller.rb)
- Added signup tests
