### PR TITLE
Remove devise cookie storage in api

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -5,6 +5,7 @@ module Api
     class ApiController < ApplicationController
       protect_from_forgery with: :null_session
       include DeviseTokenAuth::Concerns::SetUserByToken
+      before_action :skip_session_storage
 
       layout false
       respond_to :json
@@ -32,6 +33,14 @@ module Api
       def render_record_invalid(exception)
         logger.info(exception) # for logging
         render json: { errors: exception.record.errors.as_json }, status: :bad_request
+      end
+
+      private
+
+      def skip_session_storage
+        # Devise stores the cookie by default, so in api requests, it is disabled
+        # http://stackoverflow.com/a/12205114/2394842
+        request.session_options[:skip] = true
       end
     end
   end


### PR DESCRIPTION
Postman (or any other frontend that sends cookies) sends a cookie in every request, and devise by default stores it, so no matter what devise token auth does (logout, or ask for a new token every request), the session is still valid. So I removed the cookie storage in the api, this problem also is in the previous api base.

Thanks to http://stackoverflow.com/a/12205114/2394842