### PR TITLE
Fix token auth persist

### DIFF
--- a/config/initializers/rack_cors.rb
+++ b/config/initializers/rack_cors.rb
@@ -3,7 +3,10 @@ module App
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'
-        resource '*', headers: :any, methods: [:get, :post, :options, :put, :delete]
+        resource '*',
+                 headers: :any,
+                 methods: [:get, :post, :options, :put, :delete],
+                 expose:  ['access-token', 'uid', 'client']
       end
     end
   end


### PR DESCRIPTION
Fixed token auth. The token was not persisted when the user reloads the page.