### PR TITLE
add break to carrierwave 

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,8 +3,8 @@ CarrierWave.configure do |config|
     config.storage = :file
     config.enable_processing = false
   else
-    break if ENV['AWS_ACCESS_KEY_ID'].blank? || ENV['AWS_SECRET_ACCESS_KEY'].blank? || 
-             ENV['S3_BUCKET_NAME'].blank?    
+    break if ENV['AWS_ACCESS_KEY_ID'].blank? || ENV['AWS_SECRET_ACCESS_KEY'].blank? ||
+             ENV['S3_BUCKET_NAME'].blank?
     config.storage = :fog
     config.fog_credentials = {
       provider: 'AWS',


### PR DESCRIPTION
- Add break to carrierwave initializer in order to avoid fog credentials configuration if environment variables are not present