### PR TITLE
Move authenticate user callback to api controller

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -5,6 +5,8 @@ module Api
     class ApiController < ApplicationController
       protect_from_forgery with: :null_session
       include DeviseTokenAuth::Concerns::SetUserByToken
+
+      before_action :authenticate_user!, except: :status
       before_action :skip_session_storage
 
       layout false

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,6 @@
 module Api
   module V1
     class UsersController < Api::V1::ApiController
-      before_action :authenticate_user!
       def show
       end
 


### PR DESCRIPTION
In order to have authenticated users in the whole api, the callback was moved to api controller