### PR TITLE
add exception to protect_from_forgery method and add skip verify_auth…

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -3,7 +3,8 @@
 module Api
   module V1
     class ApiController < ApplicationController
-      protect_from_forgery with: :null_session
+      skip_before_filter :verify_authenticity_token, if: :json_request?
+
       include DeviseTokenAuth::Concerns::SetUserByToken
 
       before_action :authenticate_user!, except: :status
@@ -38,6 +39,10 @@ module Api
       end
 
       private
+
+      def json_request?
+        request.format.json?
+      end
 
       def skip_session_storage
         # Devise stores the cookie by default, so in api requests, it is disabled

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -3,7 +3,14 @@
 module Api
   module V1
     class PasswordsController < DeviseTokenAuth::PasswordsController
-      protect_from_forgery with: :null_session
+      protect_from_forgery with: :exception
+      skip_before_filter :verify_authenticity_token, if: :json_request?
+
+      private
+
+      def json_request?
+        request.format.json?
+      end
     end
   end
 end

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -3,7 +3,8 @@
 module Api
   module V1
     class RegistrationsController < DeviseTokenAuth::RegistrationsController
-      protect_from_forgery with: :null_session
+      protect_from_forgery with: :exception
+      skip_before_filter :verify_authenticity_token, if: :json_request?
 
       def sign_up_params
         params.require(:user).permit(:email, :password, :password_confirmation, :username)
@@ -11,6 +12,12 @@ module Api
 
       def render_create_success
         render json: resource_data
+      end
+
+      private
+
+      def json_request?
+        request.format.json?
       end
     end
   end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V1
     class SessionsController < DeviseTokenAuth::SessionsController
       protect_from_forgery with: :null_session
+      skip_before_filter :verify_authenticity_token, if: :json_request?
 
       def facebook
         user_params = FacebookService.new(params[:access_token]).profile
@@ -20,6 +21,10 @@ module Api
       end
 
       private
+
+      def json_request?
+        request.format.json?
+      end
 
       def custom_sign_in
         sign_in(:api_v1_user, @resource)


### PR DESCRIPTION
## Modify the way csrf requests are handled

#### Trello board reference:

* [Trello Card #ENHACEMENT]()

---

#### Description:

* This PR intends to modify the way CSRF token is being handled for API's. I have been researching about this topic, and some argued that CSRF token should be set to null if is being used with API. Other ones argued that this modification is the correct way to handle CSRF token for API.  This modification intends to ensure that the request fails to execute and trunk the workflow.

---

#### Reviewers:

* @MaicolBen 
* @matiasmansilla1989 
* @jiv 

---

#### Notes:

* I attach some of the documents I read in order to lean for this approach:

* https://nvisium.com/blog/2014/09/10/understanding-protectfromforgery/
* https://mathieu.fenniak.net/is-your-web-api-susceptible-to-a-csrf-exploit/
* http://stackoverflow.com/questions/10167956/rails-shows-warning-cant-verify-csrf-token-authenticity-from-a-restkit-post
* http://stackoverflow.com/questions/20745843/is-this-rails-json-authentication-api-using-devise-secure
* https://github.com/gonzalo-bulnes/simple_token_authentication/issues/67
* http://jamescpoole.com/2013/10/31/rails-4-csrf-protection-with-clients-using-apis/

---

#### Tasks:

  - [x] Change `protect_from_forgery` from `null_session` to `exception` in all API controllers

  - [x] Add skip for `verify_authenticity_token`  if the request format is `json`


---

#### Risk:

* Medium

---