### PR TITLE
Use symbols instead of strings in parsed responses in tests

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class ApiController < ApplicationController
-      skip_before_filter :verify_authenticity_token, if: :json_request?
+      skip_before_action :verify_authenticity_token, if: :json_request?
 
       include DeviseTokenAuth::Concerns::SetUserByToken
 

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class PasswordsController < DeviseTokenAuth::PasswordsController
       protect_from_forgery with: :exception
-      skip_before_filter :verify_authenticity_token, if: :json_request?
+      skip_before_action :verify_authenticity_token, if: :json_request?
 
       private
 

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class RegistrationsController < DeviseTokenAuth::RegistrationsController
       protect_from_forgery with: :exception
-      skip_before_filter :verify_authenticity_token, if: :json_request?
+      skip_before_action :verify_authenticity_token, if: :json_request?
 
       def sign_up_params
         params.require(:user).permit(:email, :password, :password_confirmation, :username)

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class SessionsController < DeviseTokenAuth::SessionsController
       protect_from_forgery with: :null_session
-      skip_before_filter :verify_authenticity_token, if: :json_request?
+      skip_before_action :verify_authenticity_token, if: :json_request?
 
       def facebook
         user_params = FacebookService.new(params[:access_token]).profile

--- a/spec/controllers/api/v1/sessions_controller_spec.rb
+++ b/spec/controllers/api/v1/sessions_controller_spec.rb
@@ -27,7 +27,7 @@ describe Api::V1::SessionsController do
       shared_context 'returns invalid credentials' do
         it 'returns an error' do
           post :create, params: params
-          expect(parsed_response['errors']).to include(error_message)
+          expect(parsed_response[:errors]).to include(error_message)
         end
       end
       let(:error_message) { 'Invalid login credentials. Please try again.' }

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -18,8 +18,8 @@ describe Api::V1::UsersController do
     it 'returns user\'s data' do
       get :show, params: { id: :me, format: :json }
 
-      expect(parsed_response['user']['id']).to eq user.id
-      expect(parsed_response['user']['first_name']).to eq user.first_name
+      expect(parsed_response[:user][:id]).to eq user.id
+      expect(parsed_response[:user][:first_name]).to eq user.first_name
     end
   end
 
@@ -40,8 +40,8 @@ describe Api::V1::UsersController do
       it 'returns the user' do
         put :update, params: { id: :me, user: params, format: 'json' }
 
-        expect(parsed_response['user']['id']).to eq user.id
-        expect(parsed_response['user']['first_name']).to eq user.first_name
+        expect(parsed_response[:user][:id]).to eq user.id
+        expect(parsed_response[:user][:first_name]).to eq user.first_name
       end
     end
 
@@ -60,7 +60,7 @@ describe Api::V1::UsersController do
 
       it 'returns the error' do
         put :update, params: { id: :me, user: params, format: 'json' }
-        expect(parsed_response['errors']['email']).to include('is not an email')
+        expect(parsed_response[:errors][:email]).to include('is not an email')
       end
     end
   end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -3,7 +3,7 @@ module Helpers
   #
   # @return [Hash]
   def parsed_response
-    JSON.parse(response.body)
+    JSON.parse(response.body).with_indifferent_access
   end
 
   def auth_request(user)


### PR DESCRIPTION
This PR includes:
- Use symbols instead of strings in parsed responses in tests, this was achieved with [with_indifferent_access](http://api.rubyonrails.org/classes/ActiveSupport/HashWithIndifferentAccess.html). Thanks to @Sebamax91 
- Replace `skip_before_filter` for `skip_before_action` because it'll be deprecated in [rails 5.1](https://github.com/rails/rails/blob/v5.0.0.beta2/actionpack/lib/abstract_controller/callbacks.rb#L190-L193)