### PR TITLE
Add webmock and shoulda

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ end
 group :test do
   gem 'database_cleaner', '~> 1.4.1'
   gem 'faker', '~> 1.4.3'
+  gem 'shoulda-matchers', '~> 3.1.1'
+  gem 'webmock', '~> 2.3.2'
 end
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       adamantium (~> 0.2.0)
       equalizer (~> 0.0.9)
     concurrent-ruby (1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
     delayed_job (4.1.2)
@@ -177,6 +179,7 @@ GEM
     has_scope (0.7.0)
       actionpack (>= 4.1, < 5.1)
       activesupport (>= 4.1, < 5.1)
+    hashdiff (0.3.2)
     i18n (0.7.0)
     ice_nine (0.11.2)
     ipaddress (0.8.3)
@@ -325,6 +328,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.1)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -335,6 +339,8 @@ GEM
     sendgrid (1.2.4)
       json
     sexp_processor (4.4.5)
+    shoulda-matchers (3.1.1)
+      activesupport (>= 4.0.0)
     slop (3.6.0)
     spring (2.0.0)
       activesupport (>= 4.2)
@@ -366,6 +372,10 @@ GEM
       procto (~> 0.0.2)
     warden (1.2.6)
       rack (>= 1.0)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -408,10 +418,12 @@ DEPENDENCIES
   rspec-rails (~> 3.5.2)
   rubocop (~> 0.32.1)
   sendgrid (~> 1.2.4)
+  shoulda-matchers (~> 3.1.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   uglifier (~> 2.7.2)
+  webmock (~> 2.3.2)
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
 
+  validates :email, uniqueness: true
+
   def full_name
     return username unless first_name.present?
     "#{first_name} #{last_name}"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,6 +32,11 @@
 require 'rails_helper'
 
 describe User do
+  describe 'validations' do
+    it { should validate_presence_of(:email) }
+    it { should validate_uniqueness_of(:email).case_insensitive }
+  end
+
   context 'when was created with regular login' do
     let!(:user) { create(:user) }
     let(:full_name) { user.full_name }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,3 +14,10 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require File.expand_path('../../config/environment', __FILE__)
 
 require 'factory_girl_rails'
 require 'helpers'
+require 'webmock/rspec'
+require 'shoulda/matchers'
 
 FactoryGirl.factories.clear
 FactoryGirl.reload


### PR DESCRIPTION
This PR includes:
- Added webmock to avoid call external APIs by default, an alternative could be mock lib/services mocking but it is easy to forget. Another alternative is `vcr` but it is more complex, webmock let you know the code to put in case you call the external API. If you want `vcr`, please make a comment here and we can discuss.
- Added shoulda as suggest in https://github.com/toptier/rails5_api_base/issues/26. [devise token auth seems to have an issue with shoulda](https://github.com/lynndylanhurley/devise_token_auth/issues/833) where it doesn't recognize the uniqueness that devise add by default in the email, if you remove `include DeviseTokenAuth::Concerns::User` in user, the email validator isn't need to add.

Closes #26