### PR TITLE
Fixed readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 1. Clone this repo
 2. Create your `database.yml` and `application.yml` file
-3. Generate a secret key with `rake secret` and paste this value into the `application.yml`
-4. `bundle install`
+3. `bundle install`
+4. Generate a secret key with `rake secret` and paste this value into the `application.yml`
 5. `rake db:create`
 6. `rake db:migrate`
 7. [Optional] Set your [frontend URL](https://github.com/cyu/rack-cors#origin) in `config/initializers/rack_cors.rb`
-8. Set your mail sender in `config/initializers/devise.rb`
+8. [Optional] Set your mail sender in `config/initializers/devise.rb`
 9. `rails s`


### PR DESCRIPTION
- You need rake in order to run `rake secret` so `bundle install` goes first in the instructions order
- The set-up of a mailer isn't mandatory so I added the `[Optional]` tag to it