### PR TITLE
Change token configuration for devise token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@
 4. Generate a secret key with `rake secret` and paste this value into the `application.yml`
 5. `rake db:create`
 6. `rake db:migrate`
-7. [Optional] Set your [frontend URL](https://github.com/cyu/rack-cors#origin) in `config/initializers/rack_cors.rb`
-8. [Optional] Set your mail sender in `config/initializers/devise.rb`
-9. `rails s`
+7. `rails s`
+
+## Optional configuration
+
+- Set your [frontend URL](https://github.com/cyu/rack-cors#origin) in `config/initializers/rack_cors.rb`
+- Set your mail sender in `config/initializers/devise.rb`
+- Decrease `token_lifespan` in `config/initializers/devise_token_auth.rb` if the frontend is a Web-app.
+- Remove Facebook code with `git revert a8319a37ab8d038399a7a6bd74fe3869bb3f3ddc`
+- Config your timezone accordingly in `application.rb`.
 
 ## Docs
 

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -2,4 +2,7 @@ DeviseTokenAuth.setup do |config|
   config.default_confirm_success_url = '/'
   config.default_password_reset_url = ENV['PASSWORD_RESET_URL']
   config.enable_standard_devise_support = true
+  config.token_lifespan = 1.year
+  config.batch_request_buffer_throttle = 10.seconds
+  config.change_headers_on_each_request = false
 end


### PR DESCRIPTION
This PR includes:
- Changed default token lifespan for a year, it should be changed for Web-apps as frontend
- Disable change tokens due to [random problems](https://github.com/lynndylanhurley/devise_token_auth/issues/702)
- Recommend in README to change the app timezone
- Increase token batch window
- Give info about how to remove facebook