### PR TITLE
Use user single resources instead of /users/me

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -52,7 +52,7 @@ API BASE is an internal Rootstrap project created to facilitate and standardize 
             }
 
 
-## Current user's profile [/api/v1/user/{id}]
+## Current user's profile [/api/v1/user/]
 
 ### Get current user profile [GET]
 
@@ -83,8 +83,8 @@ API BASE is an internal Rootstrap project created to facilitate and standardize 
                 {
                   "email": "test@test.com",
                   "username": "test",
-                  "first_name": "Juanito",
-                  "last_name": "La Cruz"
+                  "first_name": "John",
+                  "last_name": "Doe"
                 }
             }
 
@@ -105,8 +105,8 @@ API BASE is an internal Rootstrap project created to facilitate and standardize 
                 {
                   "username": "test",
                   "password": "password",
-                  "first_name": "Juanito",
-                  "last_name": "La Cruz"
+                  "first_name": "John",
+                  "last_name": "Doe"
                 }
             }
 
@@ -126,10 +126,50 @@ API BASE is an internal Rootstrap project created to facilitate and standardize 
                 {
                   "email": "test@test.com",
                   "username": "test",
-                  "first_name": "Juanito",
-                  "last_name": "La Cruz"
+                  "first_name": "John",
+                  "last_name": "Doe"
                 }
             }
+
+## Get other user's profile [/api/v1/users/{id}]
+
+### Get user [GET]
+
++ Request (application/json)
+    + Parameters
+        + id (integer, required)
+
+    + Headers
+
+            access-token: sO2bm_Bpdyoo8r78jZ-fqg
+            client: QADgNCWRJj0LyRruqzYbBg
+            uid: test@test.com
+
+
++ Response 401
+
+
++ Response 200 (application/json)
+    + Headers
+
+            access-token: sO2bm_Bpdyoo8r78jZ-fqg
+            client: QADgNCWRJj0LyRruqzYbBg
+            expiry: 1489009792
+            uid: test@test.com
+
+
+    + Body
+
+            {
+              "user":
+                {
+                  "email": "test@test.com",
+                  "username": "test",
+                  "first_name": "John",
+                  "last_name": "Doe"
+                }
+            }
+
 
 
 ## Login [/api/v1/users/sign_in]
@@ -164,7 +204,7 @@ API BASE is an internal Rootstrap project created to facilitate and standardize 
     + Body
 
             {
-              "data":
+              "user":
                 {
                   "id": 102,
                   "email": "test@test.com",
@@ -179,7 +219,7 @@ API BASE is an internal Rootstrap project created to facilitate and standardize 
             }
 
 
-## Login with Facebook [/api/v1/users/facebook]
+## Login with Facebook [/api/v1/user/facebook]
 
 ### Login with Facebook [POST]
 
@@ -195,7 +235,7 @@ API BASE is an internal Rootstrap project created to facilitate and standardize 
     + Body
 
             {
-              "data":
+              "user":
                 {
                   "id": 366,
                   "email": "test@facebook.com",
@@ -243,19 +283,7 @@ https://github.com/lynndylanhurley/devise_token_auth/wiki/Reset-Password-Flow
 
             {
               "success": true,
-              "data":
-                {
-                  "id": 781,
-                  "provider": "email",
-                  "email": "wilma_farrell@reinger.info",
-                  "uid": "wilma_farrell@reinger.info",
-                  "first_name": "",
-                  "last_name": "",
-                  "username": "39kellen_bahringer",
-                  "created_at": "2017-03-01T18:58:42.223Z",
-                  "updated_at": "2017-03-01T18:58:42.439Z"
-                },
-              "message": "An email has been sent to 'wilma_farrell@reinger.info' containing instructions for resetting your password."
+              "message": "An email has been sent to 'example@mail.com' containing instructions for resetting your password."
             }
 
 ### Reset passowrd [PUT]
@@ -285,7 +313,7 @@ https://github.com/lynndylanhurley/devise_token_auth/wiki/Reset-Password-Flow
     + Body
 
             {
-              "data":
+              "user":
                 {
                   "id": 366,
                   "email": "test@facebook.com",

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -12,7 +12,7 @@ module Api
       end
 
       def render_create_success
-        render json: resource_data
+        render json: { user: resource_data }
       end
     end
   end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -33,6 +33,10 @@ module Api
         response.headers.merge!(new_auth_header)
         render_create_success
       end
+
+      def render_create_success
+        render json: { user: resource_data }
+      end
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,11 +3,17 @@
 module Api
   module V1
     class UsersController < Api::V1::ApiController
+      helper_method :user
+
       def show
       end
 
+      def profile
+        render :show
+      end
+
       def update
-        current_user.update!(user_params)
+        user.update!(user_params)
         render :show
       end
 
@@ -15,6 +21,14 @@ module Api
 
       def user_params
         params.require(:user).permit(:username, :first_name, :last_name, :email)
+      end
+
+      def user
+        @user ||= user_id.present? ? User.find(user_id) : current_user
+      end
+
+      def user_id
+        params[:id]
       end
     end
   end

--- a/app/views/api/v1/users/show.json.jbuilder
+++ b/app/views/api/v1/users/show.json.jbuilder
@@ -1,3 +1,3 @@
 json.user do
-  json.partial! 'info', user: current_user
+  json.partial! 'info', user: user
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,9 @@ Rails.application.routes.draw do
     namespace :v1, defaults: { format: :json } do
       devise_scope :user do
         get :status, to: 'api#status'
-        resources :users, only: [:show, :update] do
+        resources :users, only: [:show]
+        resource :user, only: [:update] do
+          get :profile
           controller :sessions do
             post :facebook, on: :collection
           end

--- a/spec/requests/api/v1/passwords/create_spec.rb
+++ b/spec/requests/api/v1/passwords/create_spec.rb
@@ -17,6 +17,11 @@ describe 'POST api/v1/users/passwords', type: :request do
       expect(response).to have_http_status(:success)
     end
 
+    it 'returns the user email' do
+      post user_password_path, params: params, as: :json
+      expect(json[:message]).to match(/#{user.email}/)
+    end
+
     it 'sends an email' do
       expect { post user_password_path, params: params, as: :json }
         .to change { ActionMailer::Base.deliveries.count }.by(1)

--- a/spec/requests/api/v1/sessions/create_spec.rb
+++ b/spec/requests/api/v1/sessions/create_spec.rb
@@ -21,16 +21,13 @@ describe 'POST api/v1/users/sign_in', type: :request do
     end
 
     it 'returns the user' do
-      response_expected = {
-        id:         user.id,
-        email:      user.email,
-        username:   user.username,
-        uid:        user.email,
-        provider:   'email',
-        first_name: user.first_name,
-        last_name:  user.last_name
-      }.with_indifferent_access
-      expect(json[:data]).to eq(response_expected)
+      expect(json[:user][:id]).to eq(user.id)
+      expect(json[:user][:email]).to eq(user.email)
+      expect(json[:user][:username]).to eq(user.username)
+      expect(json[:user][:uid]).to eq(user.uid)
+      expect(json[:user][:provider]).to eq('email')
+      expect(json[:user][:first_name]).to eq(user.first_name)
+      expect(json[:user][:last_name]).to eq(user.last_name)
     end
 
     it 'returns a valid client and access token' do

--- a/spec/requests/api/v1/sessions/facebook_spec.rb
+++ b/spec/requests/api/v1/sessions/facebook_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'POST api/v1/users/facebook', type: :request do
   let(:user)              { create(:user) }
-  let(:facebook_path)     { facebook_api_v1_users_path }
+  let(:facebook_path)     { facebook_api_v1_user_path }
   let(:facebook_api_path) { 'https://graph.facebook.com/me' }
   let(:facebook_response) do
     {

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'POST api/v1/users/', type: :request do
-  let!(:user)           { create(:user) }
+  let(:user)           { User.last }
   let(:failed_response) { 422 }
 
   describe 'POST create' do
@@ -32,10 +32,21 @@ describe 'POST api/v1/users/', type: :request do
     end
 
     it 'creates the user' do
+      expect do
+        post user_registration_path, params: params, as: :json
+      end.to change(User, :count).by(1)
+    end
+
+    it 'returns the user' do
       post user_registration_path, params: params, as: :json
 
-      new_user = User.find_by_email(email)
-      expect(new_user).to_not be_nil
+      expect(json[:user][:id]).to eq(user.id)
+      expect(json[:user][:email]).to eq(user.email)
+      expect(json[:user][:username]).to eq(user.username)
+      expect(json[:user][:uid]).to eq(user.uid)
+      expect(json[:user][:provider]).to eq('email')
+      expect(json[:user][:first_name]).to eq(user.first_name)
+      expect(json[:user][:last_name]).to eq(user.last_name)
     end
 
     context 'when the email is not correct' do

--- a/spec/requests/api/v1/users/profile_spec.rb
+++ b/spec/requests/api/v1/users/profile_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'GET api/v1/user/profile', type: :request do
+  let(:user) { create(:user) }
+
+  it 'returns success' do
+    get profile_api_v1_user_path, headers: auth_headers, as: :json
+    expect(response).to have_http_status(:success)
+  end
+
+  it 'returns user\'s data' do
+    get profile_api_v1_user_path, headers: auth_headers, as: :json
+
+    expect(json[:user][:id]).to eq user.id
+    expect(json[:user][:first_name]).to eq user.first_name
+  end
+end

--- a/spec/requests/api/v1/users/show_spec.rb
+++ b/spec/requests/api/v1/users/show_spec.rb
@@ -1,17 +1,18 @@
 require 'rails_helper'
 
-describe 'GET api/v1/users/me', type: :request do
+describe 'GET api/v1/users/:id', type: :request do
   let(:user) { create(:user) }
+  let(:another_user) { create :user }
 
   it 'returns success' do
-    get api_v1_user_path(id: 'me'), headers: auth_headers, as: :json
+    get api_v1_user_path(id: another_user.id), headers: auth_headers, as: :json
     expect(response).to have_http_status(:success)
   end
 
   it 'returns user\'s data' do
-    get api_v1_user_path(id: 'me'), headers: auth_headers, as: :json
+    get api_v1_user_path(id: another_user.id), headers: auth_headers, as: :json
 
-    expect(json[:user][:id]).to eq user.id
-    expect(json[:user][:first_name]).to eq user.first_name
+    expect(json[:user][:id]).to eq another_user.id
+    expect(json[:user][:first_name]).to eq another_user.first_name
   end
 end

--- a/spec/requests/api/v1/users/update_spec.rb
+++ b/spec/requests/api/v1/users/update_spec.rb
@@ -1,23 +1,24 @@
 require 'rails_helper'
 
-describe 'PUT api/v1/users/me', type: :request do
-  let(:user) { create(:user) }
+describe 'PUT api/v1/user/', type: :request do
+  let(:user)             { create(:user) }
+  let(:api_v1_user_path) { '/api/v1/user' }
 
   context 'with valid params' do
     let(:params) {  { user: { username: 'new username' } } }
 
     it 'returns success' do
-      put api_v1_user_path(id: 'me'), params: params, headers: auth_headers, as: :json
+      put api_v1_user_path, params: params, headers: auth_headers, as: :json
       expect(response).to have_http_status(:success)
     end
 
     it 'updates the user' do
-      put api_v1_user_path(id: 'me'), params: params, headers: auth_headers, as: :json
+      put api_v1_user_path, params: params, headers: auth_headers, as: :json
       expect(user.reload.username).to eq(params[:user][:username])
     end
 
     it 'returns the user' do
-      put api_v1_user_path(id: 'me'), params: params, headers: auth_headers, as: :json
+      put api_v1_user_path, params: params, headers: auth_headers, as: :json
 
       expect(json[:user][:id]).to eq user.id
       expect(json[:user][:first_name]).to eq user.first_name
@@ -28,17 +29,17 @@ describe 'PUT api/v1/users/me', type: :request do
     let(:params) { { user: { email: 'notanemail' } } }
 
     it 'does not return success' do
-      put api_v1_user_path(id: 'me'), params: params, headers: auth_headers, as: :json
+      put api_v1_user_path, params: params, headers: auth_headers, as: :json
       expect(response).to_not have_http_status(:success)
     end
 
     it 'does not update the user' do
-      put api_v1_user_path(id: 'me'), params: params, headers: auth_headers, as: :json
+      put api_v1_user_path, params: params, headers: auth_headers, as: :json
       expect(user.reload.email).to_not eq(params[:email])
     end
 
     it 'returns the error' do
-      put api_v1_user_path(id: 'me'), params: params, headers: auth_headers, as: :json
+      put api_v1_user_path, params: params, headers: auth_headers, as: :json
       expect(json[:errors][:email]).to include('is not an email')
     end
   end

--- a/spec/routing/sessions_routing_spec.rb
+++ b/spec/routing/sessions_routing_spec.rb
@@ -7,7 +7,7 @@ describe Api::V1::SessionsController, type: :routing do
     end
 
     it 'routes to #facebook' do
-      expect(post: '/api/v1/users/facebook').to route_to('api/v1/sessions#facebook', format: :json)
+      expect(post: '/api/v1/user/facebook').to route_to('api/v1/sessions#facebook', format: :json)
     end
 
     it 'routes to #destroy' do

--- a/spec/routing/user_routing_spec.rb
+++ b/spec/routing/user_routing_spec.rb
@@ -3,11 +3,15 @@ require 'rails_helper'
 describe Api::V1::UsersController, type: :routing do
   describe 'routing' do
     it 'routes to #update' do
-      expect(put: '/api/v1/users/me').to route_to('api/v1/users#update', format: :json, id: 'me')
+      expect(put: '/api/v1/user').to route_to('api/v1/users#update', format: :json)
     end
 
     it 'routes to #show' do
-      expect(get: '/api/v1/users/me').to route_to('api/v1/users#show', format: :json, id: 'me')
+      expect(get: '/api/v1/users/1').to route_to('api/v1/users#show', format: :json, id: '1')
+    end
+
+    it 'routes to #profile' do
+      expect(get: '/api/v1/user/profile').to route_to('api/v1/users#profile', format: :json)
     end
   end
 end


### PR DESCRIPTION
Resolves #33 

Using `/users/me` make the next nested resources use the `resource_id` param instead of `id`. Also `me` isn't too much REST, it's recommended to use ids not hardcoded strings.

The downside of this, is that rails shares the same controller for the `resources :users`, so in the future if developers want  to add it, what controller do you recommend? Or maybe rename the current one as `user_controller` and tell that to the resource route.