### PR TITLE
Enable mail errors in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   end
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :letter_opener
 
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
According to the [rails guide](https://github.com/bbatsov/rails-style-guide#enable-delivery-errors) is the best practice