### PR TITLE
allow_indentation_for_json_responses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,7 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Max: 12
+
+SingleSpaceBeforeFirstArg:
+ Exclude:
+   - app/views/api/**/**/*

--- a/app/views/api/v1/users/_info.json.jbuilder
+++ b/app/views/api/v1/users/_info.json.jbuilder
@@ -1,5 +1,5 @@
-json.id user.id
-json.email user.email
-json.name user.full_name
+json.id         user.id
+json.email      user.email
+json.name       user.full_name
 json.first_name user.first_name
-json.username user.username
+json.username   user.username


### PR DESCRIPTION
This PR contains:
- Allow indentation for json views in order to improve readability.
- Exclude rubocop rule SingleSpaceBeforeFirstArg for api views.