### PR TITLE
Added 500 handler & make facebook webmock more flexible

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3,7 +3,7 @@ HOST: http://rails5-api-base.herokuapp.com
 
 # API BASE
 
-API BASE is an internal TopTier project created to facilitate and standardize developers work.
+API BASE is an internal Rootstrap project created to facilitate and standardize developers work.
 
 ## Users Collection [/api/v1/users]
 
@@ -36,7 +36,7 @@ API BASE is an internal TopTier project created to facilitate and standardize de
 
 
     + Body
-      
+
             {
               "id": 102,
               "email": "test@test.com",
@@ -75,7 +75,7 @@ API BASE is an internal TopTier project created to facilitate and standardize de
 
 
     + Body
-      
+
             {
               "user":
                 {
@@ -118,7 +118,7 @@ API BASE is an internal TopTier project created to facilitate and standardize de
 
 
     + Body
-      
+
             {
               "user":
                 {
@@ -131,7 +131,7 @@ API BASE is an internal TopTier project created to facilitate and standardize de
 
 
 ## Login [/api/v1/users/sign_in]
-  
+
 ### Login [POST]
 
 + Request (application/json)
@@ -160,7 +160,7 @@ API BASE is an internal TopTier project created to facilitate and standardize de
 
 
     + Body
-      
+
             {
               "data":
                 {
@@ -178,7 +178,7 @@ API BASE is an internal TopTier project created to facilitate and standardize de
 
 
 ## Login with Facebook [/api/v1/users/facebook]
-  
+
 ### Login with Facebook [POST]
 
 
@@ -239,7 +239,7 @@ https://github.com/lynndylanhurley/devise_token_auth/wiki/Reset-Password-Flow
 + Response 200 (application/json)
     + Body
 
-            { 
+            {
               "success": true,
               "data":
                 {

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -11,6 +11,7 @@ module Api
       layout false
       respond_to :json
 
+      rescue_from Exception,                           with: :render_error
       rescue_from ActiveRecord::RecordNotFound,        with: :render_not_found
       rescue_from ActiveRecord::RecordInvalid,         with: :render_record_invalid
       rescue_from ActionController::RoutingError,      with: :render_not_found
@@ -19,6 +20,11 @@ module Api
 
       def status
         render json: { online: true }
+      end
+
+      def render_error(_exception)
+        logger.error(exception) # Report to your error managment tool here
+        render json: { error: 'An error ocurred' }, status: 500 unless performed?
       end
 
       def render_not_found(exception)

--- a/spec/requests/api/v1/sessions/facebook_spec.rb
+++ b/spec/requests/api/v1/sessions/facebook_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 describe 'POST api/v1/users/facebook', type: :request do
-  let(:user)          { create(:user) }
-  let(:facebook_path) { facebook_api_v1_users_path }
+  let(:user)              { create(:user) }
+  let(:facebook_path)     { facebook_api_v1_users_path }
+  let(:facebook_api_path) { 'https://graph.facebook.com/me' }
   let(:facebook_response) do
     {
       first_name: 'Test',
@@ -30,7 +31,8 @@ describe 'POST api/v1/users/facebook', type: :request do
       }
     end
     before do
-      stub_request(:get, 'https://graph.facebook.com/me?access_token=123456&fields=email,first_name,last_name')
+      stub_request(:get, facebook_api_path)
+        .with(query: hash_including(access_token: '123456', fields: 'email,first_name,last_name'))
         .to_return(status: 200, body: facebook_response.to_json)
     end
 
@@ -77,7 +79,9 @@ describe 'POST api/v1/users/facebook', type: :request do
       end
       before do
         facebook_response[:email] = ''
-        stub_request(:get, 'https://graph.facebook.com/me?access_token=without_email&fields=email,first_name,last_name')
+        fields = 'email,first_name,last_name'
+        stub_request(:get, facebook_api_path)
+          .with(query: hash_including(access_token: 'without_email', fields: fields))
           .to_return(status: 200, body: facebook_response.to_json)
       end
 
@@ -121,7 +125,8 @@ describe 'POST api/v1/users/facebook', type: :request do
           code: 190
         }
       }
-      stub_request(:get, 'https://graph.facebook.com/me?access_token=invalid&fields=email,first_name,last_name')
+      stub_request(:get, facebook_api_path)
+        .with(query: hash_including(access_token: 'invalid', fields: 'email,first_name,last_name'))
         .to_return(status: 400, body: facebook_response.to_json)
     end
 


### PR DESCRIPTION
This PR includes:
- Update company name in the api doc
- Handle 500 error, let me know if you don't agree with this change
- Make facebook webmock more flexible in case of adding params in the path