### PR TITLE
Fix wrong parameter after add error logging

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -22,7 +22,7 @@ module Api
         render json: { online: true }
       end
 
-      def render_error(_exception)
+      def render_error(exception)
         logger.error(exception) # Report to your error managment tool here
         render json: { error: 'An error ocurred' }, status: 500 unless performed?
       end


### PR DESCRIPTION
After add error logging in #58, I forgot to make the `exception` as usable in the method `render_error`