### PR TITLE
Fix for Devise Token Auth Issue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be an Integer or
   # a Float.
   Max: 15
+  Exclude:
+    - 'app/controllers/api/v1/sessions_controller.rb'
 
 Metrics/BlockNesting:
   Max: 4
@@ -19,6 +21,8 @@ Metrics/ModuleLength:
 # Avoid complex methods.
 Metrics/CyclomaticComplexity:
   Max: 6
+  Exclude:
+    - 'app/controllers/api/v1/sessions_controller.rb'
 
 Metrics/LineLength:
   Max: 100
@@ -32,6 +36,8 @@ Metrics/LineLength:
 Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 24
+  Exclude:
+    - 'app/controllers/api/v1/sessions_controller.rb'
 
 Metrics/ParameterLists:
   Max: 5
@@ -39,6 +45,8 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Max: 12
+  Exclude:
+    - 'app/controllers/api/v1/sessions_controller.rb'
 
 SingleSpaceBeforeFirstArg:
  Exclude:

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -6,6 +6,60 @@ module Api
       protect_from_forgery with: :null_session
       include Concerns::ActAsApiRequest
 
+      def create
+        field = (resource_params.keys.map(&:to_sym) & resource_class.authentication_keys).first
+
+        @resource = nil
+        if field
+          q_value = resource_params[field]
+
+          if resource_class.case_insensitive_keys.include?(field)
+            q_value.downcase!
+          end
+
+          q = "#{field} = ? AND provider='email'"
+
+          if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+            q = 'BINARY ' + q
+          end
+
+          @resource = resource_class.where(q, q_value).first
+        end
+
+        if @resource && valid_params?(field, q_value) &&
+           (!@resource.respond_to?(:active_for_authentication?) ||
+           @resource.active_for_authentication?)
+          valid_password = @resource.valid_password?(resource_params[:password])
+          if (@resource.respond_to?(:valid_for_authentication?) &&
+             !@resource.valid_for_authentication? { valid_password }) || !valid_password
+            render_create_error_bad_credentials
+            return
+          end
+          # create client id
+          @client_id = SecureRandom.urlsafe_base64(nil, false)
+          @token     = SecureRandom.urlsafe_base64(nil, false)
+
+          @resource.tokens = JSON.parse(@resource.tokens) if @resource.tokens.is_a? String
+
+          @resource.tokens[@client_id] = {
+            token: BCrypt::Password.create(@token),
+            expiry: (Time.now + DeviseTokenAuth.token_lifespan).to_i
+          }
+          @resource.save
+
+          sign_in(:user, @resource, store: false, bypass: false)
+
+          yield @resource if block_given?
+
+          render_create_success
+        elsif @resource && !(!@resource.respond_to?(:active_for_authentication?) ||
+              @resource.active_for_authentication?)
+          render_create_error_not_confirmed
+        else
+          render_create_error_bad_credentials
+        end
+      end
+
       def facebook
         user_params = FacebookService.new(params[:access_token]).profile
         @resource = User.from_social_provider 'facebook', user_params

--- a/config.reek
+++ b/config.reek
@@ -17,7 +17,7 @@ DataClump:
   min_clump_size: 2
 DuplicateMethodCall:
   enabled: true
-  exclude: []
+  exclude: [SessionsController#create]
   max_calls: 1
   allow_calls: []
 FeatureEnvy:
@@ -65,6 +65,7 @@ TooManyStatements:
   exclude:
   - initialize
   - ApplicationController#global_search
+  - SessionsController#create
   max_statements: 12
 UncommunicativeMethodName:
   enabled: true
@@ -92,7 +93,7 @@ UncommunicativeParameterName:
   accept: []
 UncommunicativeVariableName:
   enabled: true
-  exclude: []
+  exclude: [SessionsController#create]
   reject:
   - !ruby/regexp /^.$/
   - !ruby/regexp /[0-9]$/

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -12,7 +12,7 @@ MoveCodeIntoControllerCheck: { }
 MoveCodeIntoHelperCheck: { array_count: 3 }
 MoveCodeIntoModelCheck: { use_count: 2 }
 MoveFinderToNamedScopeCheck: { }
-MoveModelLogicIntoModelCheck: { use_count: 4 }
+MoveModelLogicIntoModelCheck: { use_count: 4, ignored_files: [app/controllers/api/v1/sessions_controller.rb] }
 NeedlessDeepNestingCheck: { nested_count: 2 }
 NotRescueExceptionCheck: { }
 NotUseDefaultRouteCheck: { }

--- a/spec/requests/api/v1/sessions/create_spec.rb
+++ b/spec/requests/api/v1/sessions/create_spec.rb
@@ -2,7 +2,23 @@ require 'rails_helper'
 
 describe 'POST api/v1/users/sign_in', type: :request do
   let(:password) { 'password' }
-  let(:user)     { create(:user, password: password) }
+  let(:token) do
+    { '70crCAAYmNP1xLkKKM09zA' =>
+      {
+        'token' => '$2a$10$mSeRnpVMaaegCpn3AhORGe5wajFhgMoBjGIrMwq4Qq2mP6f/OHu1y',
+        'expiry' => 153_574_356_4
+      }
+    }
+  end
+  let(:token_as_string) do
+    "{
+      \"70crCAAYmNP1xLkKKM09zA\": {
+        \"token\":\"$2a$10$mSeRnpVMaaegCpn3AhORGe5wajFhgMoBjGIrMwq4Qq2mP6f/OHu1y\",
+        \"expiry\":1535743564
+      }
+    }"
+  end
+  let(:user)     { create(:user, password: password, tokens: token) }
 
   context 'with correct params' do
     before do
@@ -52,6 +68,40 @@ describe 'POST api/v1/users/sign_in', type: :request do
         errors: ['Invalid login credentials. Please try again.']
       }.with_indifferent_access
       expect(json).to eq(expected_response)
+    end
+  end
+
+  context 'with stringified tokens' do
+    before do
+      user.update_column(:tokens, token_as_string)
+      params = {
+        user:
+          {
+            email: user.email,
+            password: password
+          }
+      }
+      post new_user_session_path, params: params, as: :json
+    end
+
+    it 'returns success' do
+      expect(response).to be_success
+    end
+
+    it 'returns the user' do
+      expect(json[:user][:id]).to eq(user.id)
+      expect(json[:user][:email]).to eq(user.email)
+      expect(json[:user][:username]).to eq(user.username)
+      expect(json[:user][:uid]).to eq(user.uid)
+      expect(json[:user][:provider]).to eq('email')
+      expect(json[:user][:first_name]).to eq(user.first_name)
+      expect(json[:user][:last_name]).to eq(user.last_name)
+    end
+
+    it 'returns a valid client and access token' do
+      token = response.header['access-token']
+      client = response.header['client']
+      expect(user.reload.valid_token?(token, client)).to be_truthy
     end
   end
 end


### PR DESCRIPTION
Issue: https://github.com/rootstrap/rails_api_base/issues/73

This PR contains: 
- Override of Devise Token Auth 'create' method in Session Controller that allows us to prevent a crash on sign in. 
- Testing for the case when the 'tokens' field is of type string.
- Necessary addition of exceptions in rubocop and reek because 'create' is an inherited method from the Devise Token Auth gem. 