### PR TITLE
Import devise token auth using https

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,0 @@
-engines:
-  bundler-audit:
-    enabled: true
-    checks:
-      Insecure Source:
-        enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'carrierwave', '~> 0.11.2'
 gem 'carrierwave-base64', '~> 2.3.4'
 gem 'delayed_job_active_record', '~> 4.1.2'
 gem 'devise', '~> 4.3.0'
-gem 'devise_token_auth', github: 'rootstrap/devise_token_auth'
+gem 'devise_token_auth', git: 'https://github.com/rootstrap/devise_token_auth'
 gem 'draper', '~> 3.0.0'
 gem 'fog-aws', '~> 0.12.0'
 gem 'haml-rails', '~> 1.0.0'
@@ -65,4 +65,4 @@ group :assets do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'tzinfo-data', platforms: %i(mingw mswin x64_mingw jruby)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/rootstrap/devise_token_auth.git
+  remote: https://github.com/rootstrap/devise_token_auth
   revision: c1bb7120a6be2c71c635a04aa12605347588bca1
   specs:
     devise_token_auth (0.1.42)


### PR DESCRIPTION
#### Description:
- Import Devise token auth gem using https as code climate suggests.
- Remove `codeclimate.yml` file. An issue https://github.com/rootstrap/rails_api_base/issues/91 is opened to discuss and create a new `codeclimate.yml` file with the proper configuration.