### PR TITLE
remove unnecessary check for cucumber env

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,5 +1,5 @@
 CarrierWave.configure do |config|
-  if Rails.env.test? || Rails.env.cucumber?
+  if Rails.env.test?
     config.storage = :file
     config.enable_processing = false
   else


### PR DESCRIPTION
## Remove cucumber check from carrierwave initializer
#### Trello board reference:

* [Trello Card #ENHACEMENT]()

---

#### Description:

* This PR remove checking from cucumber env since it's not being used either the gem is included in the gemfile
---

#### Reviewers:

* @MaicolBen
* @matiasmansilla1989
* @santiagovidal 

---

#### Notes:

*

---

#### Tasks:

  - [x] Remove cucumber check from carrierwave initializer

---

#### Risk:

 Options: (None, little, Medium, Risky)

* little

---


#### Preview:



---