### PR TITLE
Override devise render error to be consistent with the API

### DIFF
--- a/app/controllers/api/concerns/act_as_api_request.rb
+++ b/app/controllers/api/concerns/act_as_api_request.rb
@@ -18,6 +18,13 @@ module Api
         # http://stackoverflow.com/a/12205114/2394842
         request.session_options[:skip] = true
       end
+
+      def render_error(status, message, _data = nil)
+        response = {
+          error: message
+        }
+        render json: response, status: status
+      end
     end
   end
 end

--- a/spec/requests/api/v1/sessions/create_spec.rb
+++ b/spec/requests/api/v1/sessions/create_spec.rb
@@ -58,8 +58,7 @@ describe 'POST api/v1/users/sign_in', type: :request do
 
       expect(response).to be_unauthorized
       expected_response = {
-        success: false,
-        errors: ['Invalid login credentials. Please try again.']
+        error: 'Invalid login credentials. Please try again.'
       }.with_indifferent_access
       expect(json).to eq(expected_response)
     end


### PR DESCRIPTION
Resolves #101

This PR handles this issue #101 overriding the render_error method from devise (added by @MaicolBen in this PR https://github.com/lynndylanhurley/devise_token_auth/pull/989 ) to be more consistent with the way the API render the errors or an error