### PR TITLE
Add access_token param to Login with Facebook documentation

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -148,6 +148,13 @@ Rails Api Base is a boilerplate project for JSON RESTful APIs. It follows the co
 
 ### Login with Facebook [POST]
 
++ Request (application/json)
+
+    + Body
+
+            {
+              "access_token": "facebook-access-token"
+            }
 
 + Response 200 (application/json)
     + Headers


### PR DESCRIPTION
The `access_token` was missing from the documentation.