### PR TITLE
Remove Exception handler on controllers for test

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -26,6 +26,8 @@ module Api
       private
 
       def render_error(exception)
+        raise exception if Rails.env.test?
+
         logger.error(exception) # Report to your error managment tool here
         render json: { error: I18n.t('api.errors.server') }, status: 500 unless performed?
       end


### PR DESCRIPTION
On testing, don't handle Exception on the controllers and
let it bubble up.