### PR TITLE
Enable pending test, fix fog-aws import & use FactoryBot.lint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,4 +453,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.3
+   1.16.1

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class ApiController < ApplicationController
-      include Concerns::ActAsApiRequest
+      include Api::Concerns::ActAsApiRequest
       include DeviseTokenAuth::Concerns::SetUserByToken
 
       before_action :authenticate_user!, except: :status

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class PasswordsController < DeviseTokenAuth::PasswordsController
       protect_from_forgery with: :exception
-      include Concerns::ActAsApiRequest
+      include Api::Concerns::ActAsApiRequest
       skip_before_action :check_json_request, on: :edit
     end
   end

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class RegistrationsController < DeviseTokenAuth::RegistrationsController
       protect_from_forgery with: :exception
-      include Concerns::ActAsApiRequest
+      include Api::Concerns::ActAsApiRequest
 
       def sign_up_params
         params.require(:user).permit(:email, :password, :password_confirmation,

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class SessionsController < DeviseTokenAuth::SessionsController
       protect_from_forgery with: :null_session
-      include Concerns::ActAsApiRequest
+      include Api::Concerns::ActAsApiRequest
 
       def facebook
         user_params = FacebookService.new(params[:access_token]).profile

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -5,6 +5,7 @@ CarrierWave.configure do |config|
   else
     break if ENV['AWS_ACCESS_KEY_ID'].blank? || ENV['AWS_SECRET_ACCESS_KEY'].blank? ||
              ENV['S3_BUCKET_NAME'].blank? || ENV['AWS_BUCKET_REGION'].blank?
+    config.fog_provider = 'fog/aws'
     config.storage = :fog
     config.fog_credentials = {
       provider: 'AWS',

--- a/spec/factories/spec.rb
+++ b/spec/factories/spec.rb
@@ -1,7 +1,0 @@
-describe FactoryBot do
-  FactoryBot.factories.map(&:name).each do |factory_name|
-    describe "The #{factory_name} factory" do
-      it { expect(FactoryBot.build(factory_name)).to be_valid }
-    end
-  end
-end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,8 +44,7 @@ describe User do
 
     context 'when was created with regular login' do
       subject { build :user }
-      # Pending test until https://github.com/lynndylanhurley/devise_token_auth/pull/865 is merged
-      xit { should validate_uniqueness_of(:email).case_insensitive.scoped_to(:provider) }
+      it { should validate_uniqueness_of(:email).case_insensitive.scoped_to(:provider) }
       it { should validate_presence_of(:email) }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,10 @@ RSpec.configure do |config|
   end
   config.include FactoryBot::Syntax::Methods
 
+  config.before :suite do
+    FactoryBot.lint unless config.files_to_run.one?
+  end
+
   config.before :each do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.start


### PR DESCRIPTION
This PR includes:
- Fix `ActAsApiRequest` import, sometimes depending on the order of the import, this is something that breaks
- Resolves #111 (use `FactoryBot.lint` instead)
- Enable user pending test 
- After upgrading ruby, `fog-aws` [wasn't imported correctly by carrierwave](https://github.com/fog/fog/issues/3429), so I declared the provider
