### PR TITLE
Change default generators

### DIFF
--- a/config.reek
+++ b/config.reek
@@ -108,3 +108,6 @@ UnusedPrivateMethod:
   enabled: false
 UtilityFunction:
   enabled: false
+
+exclude_paths:
+  - config

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,10 @@ module App
     config.action_mailer.default_options = {
       from: 'no-reply@api.com'
     }
+
+    config.generators do |g|
+      g.test_framework :rspec
+      g.fixture_replacement :factory_bot, dir: 'spec/factories'
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,8 +22,6 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  config.filter_run_excluding on_refactor: true
-
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.order = 'random'
   config.expect_with :rspec do |c|


### PR DESCRIPTION
Instead of tests and fixtures, we use `rspec` and factory bot, so I changed the default generators, useful for model generation. 
Also, I removed a rspec filter we don't use