### PR TITLE
Prevent app failure because figaro required vars

### DIFF
--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -3,13 +3,7 @@ variables = %w[SERVER_URL PASSWORD_RESET_URL]
 
 unless Rails.env.test?
   # Variables not used by the test environment
-  variables += %w[SECRET_KEY_BASE
-                  SENDGRID_USERNAME
-                  SENDGRID_PASSWORD
-                  AWS_ACCESS_KEY_ID
-                  AWS_SECRET_ACCESS_KEY
-                  S3_BUCKET_NAME
-                  AWS_BUCKET_REGION]
+  variables += %w[SECRET_KEY_BASE]
 end
 
 Figaro.require_keys(variables)


### PR DESCRIPTION
When projects start with application.yml from the example it fails because figaro required vars. Adding empty strings prevent it to fail when you don't use them at the start