### PR TITLE
Remove unused json_request? method

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -15,10 +15,6 @@ module Api
       def render_create_success
         render json: { user: resource_data }
       end
-
-      def json_request?
-        request.format.json?
-      end
     end
   end
 end


### PR DESCRIPTION
This method was left there by accident. We can remove it now.