### PR TITLE
Return 404 when RecordNotFound happens in a view

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -28,6 +28,11 @@ module Api
       def render_error(exception)
         raise exception if Rails.env.test?
 
+        # To properly handle RecordNotFound errors in views
+        if exception.cause.is_a?(ActiveRecord::RecordNotFound)
+          return render_not_found(exception)
+        end
+
         logger.error(exception) # Report to your error managment tool here
         render json: { error: I18n.t('api.errors.server') }, status: 500 unless performed?
       end


### PR DESCRIPTION
Solves https://github.com/rootstrap/rails_api_base/issues/134

The proposed solution is to use the exception's message to check if the API should return a 404.