### PR TITLE
fix default belongs_to presence validation

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -9,7 +9,7 @@
 ActiveSupport.to_time_preserves_timezone = true
 
 # Require `belongs_to` associations by default. Previous versions had false.
-Rails.application.config.active_record.belongs_to_required_by_default = true
+ActiveRecord::Base.belongs_to_required_by_default = true
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
This PR is intended to fix an issue with the new_framework_default initializer which is supposed to have the configuration to make sure that a belongs_to association validates the presence of the record by default. 

Right now as we check it with @jdrosales17  and @JuanfraM this is not working and with this change we fix that issue