### PR TITLE
Convert to rspec 3 some rspec 2 specs

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,12 +34,12 @@ require 'rails_helper'
 describe User do
   describe 'validations' do
     subject { build :user }
-    it { should validate_uniqueness_of(:uid).scoped_to(:provider) }
+    it { is_expected.to validate_uniqueness_of(:uid).scoped_to(:provider) }
 
     context 'when was created with regular login' do
       subject { build :user }
-      it { should validate_uniqueness_of(:email).case_insensitive.scoped_to(:provider) }
-      it { should validate_presence_of(:email) }
+      it { is_expected.to validate_uniqueness_of(:email).case_insensitive.scoped_to(:provider) }
+      it { is_expected.to validate_presence_of(:email) }
     end
   end
 


### PR DESCRIPTION
#### Description:

* Change to RSpec 3 syntax some specs that used RSpec 2. 
The gem [transpec](https://github.com/yujinakayama/transpec) was used to ensure that there is no missing RSpec 2 examples.
