### PR TITLE
Enforce the usage of braces for chaining

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,3 +62,6 @@ Style/FrozenStringLiteralComment:
 
 Style/ModuleFunction:
   Enabled: false
+
+Style/BlockDelimiters:
+  EnforcedStyle: braces_for_chaining

--- a/spec/requests/api/v1/passwords/create_spec.rb
+++ b/spec/requests/api/v1/passwords/create_spec.rb
@@ -29,9 +29,9 @@ describe 'POST api/v1/users/passwords', type: :request do
     end
 
     it 'does not send an email' do
-      expect do
+      expect {
         post user_password_path, params: { email: 'notvalid@example.com' }, as: :json
-      end.to change { ActionMailer::Base.deliveries.count }.by(0)
+      }.to change { ActionMailer::Base.deliveries.count }.by(0)
     end
   end
 end

--- a/spec/requests/api/v1/sessions/destroy_spec.rb
+++ b/spec/requests/api/v1/sessions/destroy_spec.rb
@@ -11,9 +11,9 @@ describe 'DELETE api/v1/users/sign_out', type: :request do
 
     it 'decrements the amount of user tokens' do
       headers = auth_headers
-      expect do
+      expect {
         delete destroy_user_session_path, headers: headers, as: :json
-      end.to change { user.reload.tokens.size }.by(-1)
+      }.to change { user.reload.tokens.size }.by(-1)
     end
   end
 

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -32,9 +32,9 @@ describe 'POST api/v1/users/', type: :request do
     end
 
     it 'creates the user' do
-      expect do
+      expect {
         post user_registration_path, params: params, as: :json
-      end.to change(User, :count).by(1)
+      }.to change(User, :count).by(1)
     end
 
     it 'returns the user' do
@@ -53,9 +53,9 @@ describe 'POST api/v1/users/', type: :request do
       let(:email) { 'invalid_email' }
 
       it 'does not create a user' do
-        expect do
+        expect {
           post user_registration_path, params: params, as: :json
-        end.not_to change { User.count }
+        }.not_to change { User.count }
       end
 
       it 'does not return a successful response' do


### PR DESCRIPTION
Seems like it's something we already decided about in the [tech guides](https://github.com/rootstrap/tech-guides/tree/master/ruby#single-line-blocks), so I'm adding the corresponding rule here.

Personally, I agree it's nicer to user braces when chaining. Example:
```ruby
expect do
  run_job
end.to change(User, :count).by(1)

# or

expect {
  run_job
}.to change(User, :count).by(1)
```