### PR TITLE
Remove Database Cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ group :development do
 end
 
 group :test do
-  gem 'database_cleaner', '~> 1.4.1'
   gem 'faker', '~> 1.7.3'
   gem 'shoulda-matchers', '~> 3.1.1'
   gem 'simplecov', '~> 0.13.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,6 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    database_cleaner (1.4.1)
     debug_inspector (0.0.3)
     delayed_job (4.1.5)
       activesupport (>= 3.0, < 5.3)
@@ -388,7 +387,6 @@ DEPENDENCIES
   bootsnap (~> 1.3.0)
   brakeman (~> 4.3.1)
   bullet (~> 5.7.5)
-  database_cleaner (~> 1.4.1)
   delayed_job_active_record (~> 4.1.3)
   devise (~> 4.4.3)
   devise_token_auth (~> 0.1.43)
@@ -424,4 +422,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ This template comes with:
 - [Brakeman](https://github.com/presidentbeef/brakeman) for static analysis security
 - [Bullet](https://github.com/flyerhzm/bullet) help to kill N+1
 - [Byebug](https://github.com/deivid-rodriguez/byebug) for debugging
-- [Database Cleaner](https://github.com/DatabaseCleaner/database_cleaner) for cleaning test database
 - [DelayedJob](https://github.com/collectiveidea/delayed_job) for background processing
 - [Devise](https://github.com/plataformatec/devise) for basic auth
 - [Devise Token Auth](https://github.com/lynndylanhurley/devise_token_auth) for api auth

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,17 +29,7 @@ RSpec.configure do |config|
   end
   config.include FactoryBot::Syntax::Methods
 
-  config.before :suite do
-    DatabaseCleaner.cleaning { FactoryBot.lint } unless config.files_to_run.one?
-  end
-
   config.before :each do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.start
     ActionMailer::Base.deliveries.clear
-  end
-
-  config.after do
-    DatabaseCleaner.clean
   end
 end


### PR DESCRIPTION
With @santib, we removed Database Cleaner in The List project, which has Rails 5.2 and some Capybara tests, and everything worked fine (all the tests passed).

As @santib explains in https://github.com/rootstrap/rails_api_base/issues/139, from Rails 5.1.5 this gem is not needed anymore, so this PR removes the use of it.