### PR TITLE
Turn methods private in RegistrationsController and SessionsController

### DIFF
--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -6,6 +6,8 @@ module Api
       protect_from_forgery with: :exception
       include Api::Concerns::ActAsApiRequest
 
+      private
+
       def sign_up_params
         params.require(:user).permit(:email, :password, :password_confirmation,
                                      :username, :first_name, :last_name)

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -6,11 +6,11 @@ module Api
       protect_from_forgery with: :null_session
       include Api::Concerns::ActAsApiRequest
 
+      private
+
       def resource_params
         params.require(:user).permit(:email, :password)
       end
-
-      private
 
       def render_create_success
         render json: { user: resource_data }


### PR DESCRIPTION
This PR include:
- Turn `sign_up_params` and `render_create_success ` methods  into private methods in  `RegistrationsController `

- Turn `resource_params` method into private method in `SessionsController `

There is no reason to keep these methods public in the controllers