### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,51 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+
+# *       @global-owner1 @global-owner2   (remove # at beginning of line to make it work)
+
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+
+# *.js    @js-owner                       (remove # at beginning of line to make it work)
+
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+
+# *.go    docs@example.com                (remove # at beginning of line to make it work)
+
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+
+# /build/logs/ @doctocat                  (remove # at beginning of line to make it work)
+
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+
+# docs/*  docs@example.com                (remove # at beginning of line to make it work)
+
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+
+# apps/   @octocat                        (remove # at beginning of line to make it work)
+
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository.
+
+# /docs/  @doctocat                       (remove # at beginning of line to make it work)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Rails Api Base is a boilerplate project for JSON RESTful APIs. It follows the co
 
 Finally, it contains a plug an play Administration console (thanks to [ActiveAdmin](https://github.com/activeadmin/activeadmin)).
 
-
 ## Features
 
 This template comes with:
@@ -80,7 +79,6 @@ This template comes with:
 
 http://docs.railsapibase.apiary.io
 
-
 ## Code quality
 
 With `rake code_analysis` you can run the code analysis tool, you can omit rules with:
@@ -95,6 +93,12 @@ With `rake code_analysis` you can run the code analysis tool, you can omit rules
 1. After adding the project to CC, go to `Repo Settings`
 2. On the `Test Coverage` tab, copy the `Test Reporter ID`
 3. Replace the current value of `CC_TEST_REPORTER_ID` on the `config.yml file (.circleci/config.yml)` with the one you copied from CC
+
+## Code Owners
+
+You can use [CODEOWNERS](https://help.github.com/en/articles/about-code-owners) file to define individuals or teams that are responsible for code in the repository.
+
+Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.
 
 ## Credits
 


### PR DESCRIPTION
CODEOWNERS file is added. 

This way users can be set as responsible for the project's code, and they will be automatically requested for review when a PR is opened.