### PR TITLE
Enhancement - Migrate linters to CodeClimate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,10 @@ jobs:
           name: run tests
           command: RAILS_ENV=test bundle exec rspec
 
-      # run code_analysis!
+      # run rails_best_practices!
       - run:
-          name: run code analysis
-          command: RAILS_ENV=test bundle exec rake code_analysis
+          name: run rails best practices
+          command: RAILS_ENV=test bundle exec rake rails_best_practices
 
       - store_test_results:
           path: /tmp/test-results

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -64,3 +64,7 @@ plugins:
       file: '.rubocop.yml'
     exclude_patterns:
       - db/**/*
+  reek:
+    enabled: true
+    config:
+      file: '.reek.yml'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -65,6 +65,7 @@ plugins:
       file: '.rubocop.yml'
     exclude_patterns:
       - db/**/*
+      - bin/
   reek:
     enabled: true
     channel: reek-5-3-1

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -43,6 +43,7 @@ checks:
 plugins:
   brakeman:
     enabled: true
+    channel: brakeman-4-45
   bundler-audit:
     enabled: true
   csslint:
@@ -59,12 +60,13 @@ plugins:
       - spec/**/*
   rubocop:
     enabled: true
-    channel: rubocop-0-49
+    channel: rubocop-0-65
     config:
       file: '.rubocop.yml'
     exclude_patterns:
       - db/**/*
   reek:
     enabled: true
+    channel: reek-5-3-1
     config:
       file: '.reek.yml'

--- a/lib/tasks/rails_best_practices.rake
+++ b/lib/tasks/rails_best_practices.rake
@@ -1,0 +1,3 @@
+task :rails_best_practices do
+  sh 'bundle exec rails_best_practices .'
+end


### PR DESCRIPTION
Since CodeClimate supports Reek plugin we are migrating `reek` check from CircleCI to CodeClimate.

- Now in `.circleci/config.yml` only includes `rails_best_practices` check which is the only linter that isn't supported by CodeClimate.

- Now `.codeclimate.yml` includes `brakeman` , `rubocop` and  `reek`.

- We still keep `code_analysis` rake task in order to run it locally.