### PR TITLE
Remove channel specification for Brakeman, Reek and Rubocop CC plugins

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -43,7 +43,6 @@ checks:
 plugins:
   brakeman:
     enabled: true
-    channel: brakeman-4-45
   bundler-audit:
     enabled: true
   csslint:
@@ -65,7 +64,6 @@ plugins:
       file: '.rubocop.yml'
   reek:
     enabled: true
-    channel: reek-5-3-1
     config:
       file: '.reek.yml'
 exclude_patterns:


### PR DESCRIPTION
Remove channel specification for the following CodeClimate plugins:
- Brakeman
- Reek
- Rubocop

Based on this issue https://github.com/rootstrap/rails_api_base/issues/160 we are removing channels specifications in favor of using the `stable` version of each plugins.

According to this [doc](https://docs.codeclimate.com/docs/engine-channels), leaving the channel field unspecified, an analysis runs the stable channel of a plugin.