### PR TITLE
Move back code_analysis task to Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,10 @@ jobs:
           name: run tests
           command: RAILS_ENV=test bundle exec rspec
 
-      # run rails_best_practices!
+      # run code_analysis!
       - run:
-          name: run rails best practices
-          command: RAILS_ENV=test bundle exec rake rails_best_practices
+          name: run code analysis
+          command: RAILS_ENV=test bundle exec rake code_analysis
 
       - store_test_results:
           path: /tmp/test-results

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -41,9 +41,6 @@ checks:
     config:
       threshold: #language-specific defaults. overrides affect all languages.
 plugins:
-  brakeman:
-    enabled: true
-    channel: brakeman-4-45
   bundler-audit:
     enabled: true
   csslint:
@@ -58,15 +55,5 @@ plugins:
       - db/**/*
       - config/**/*
       - spec/**/*
-  rubocop:
-    enabled: true
-    channel: rubocop-0-71
-    config:
-      file: '.rubocop.yml'
-  reek:
-    enabled: true
-    channel: reek-5-3-1
-    config:
-      file: '.reek.yml'
 exclude_patterns:
   - 'babel.config.js'

--- a/lib/tasks/rails_best_practices.rake
+++ b/lib/tasks/rails_best_practices.rake
@@ -1,3 +1,0 @@
-task :rails_best_practices do
-  sh 'bundle exec rails_best_practices .'
-end


### PR DESCRIPTION
- Remove code analysis tools from CodeClimate since we are having issues with the channels for `Rubocop`, `Reek` and `Brakeman` plugins. At the moment there is a mismatch between the plugins version in CC and the versions in the Api Base Gemfile.

- run `RAILS_ENV=test bundle exec rake code_analysis` as a CircleCI step.

Note: This is a temporary workaround until we find a better way or when we have more plugins versions available in channels supported by CodeCimate.