### PR TITLE
Exclude specs when measuring test coverage

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,4 +50,34 @@ describe User do
       expect(full_name).to eq(user.username)
     end
   end
+
+  context 'when user has first_name' do
+    let!(:user) { create(:user, first_name: 'John', last_name: 'Doe') }
+
+    it 'returns the correct name' do
+      expect(user.full_name).to eq('John Doe')
+    end
+  end
+
+  describe '.from_social_provider' do
+    context 'when user does not exists' do
+      let(:params) { attributes_for(:user) }
+
+      it 'creates the user' do
+        expect {
+          User.from_social_provider('provider', params)
+        }.to change { User.count }.by(1)
+      end
+    end
+
+    context 'when the user exists' do
+      let!(:user)  { create(:user, provider: 'provider', uid: 'user@example.com') }
+      let(:params) { attributes_for(:user).merge('id' => 'user@example.com') }
+
+      it 'returns the given user' do
+        expect(User.from_social_provider('provider', params))
+          .to eq(user)
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,14 +1,19 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
+require 'simplecov'
+
+SimpleCov.start do
+  add_filter 'app/admin'
+  add_filter 'config'
+  add_filter 'spec'
+end
+
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/core'
 require 'spec_helper'
 require 'rspec/rails'
-require 'simplecov'
-
-SimpleCov.start
 
 ActiveRecord::Migration.maintain_test_schema!
 WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/requests/api/v1/status_spec.rb
+++ b/spec/requests/api/v1/status_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'GET api/v1/status', type: :request do
+  context 'with invalid content type' do
+    it 'returns status 406 not acceptable' do
+      get api_v1_status_path
+
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+
+  context 'with valid content type' do
+    before do
+      get api_v1_status_path, as: :json
+    end
+
+    it 'returns status 200 ok' do
+      expect(response).to be_successful
+    end
+
+    it 'returns the api status' do
+      expect(json['online']).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Description

Test coverage should reveal which lines of code are we missing to test, it shouldn't measure that on the tests itself.
