### PR TITLE
Issue fix: Rememberable devise module removed

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
 
   validates :uid, uniqueness: { scope: :provider }

--- a/db/migrate/20161011151353_devise_create_users.rb
+++ b/db/migrate/20161011151353_devise_create_users.rb
@@ -11,7 +11,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.0]
       t.boolean  :allow_password_change, default: false
 
       ## Rememberable
-      t.datetime :remember_created_at
+      # t.datetime :remember_created_at
 
       ## Trackable
       t.integer  :sign_in_count, default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,7 +74,6 @@ ActiveRecord::Schema.define(version: 2018_11_02_142200) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.boolean "allow_password_change", default: false
-    t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"


### PR DESCRIPTION
Devise module and column `Rememberable` removed from `user` model and table.

Issue: https://github.com/rootstrap/rails_api_base/issues/171