### PR TITLE
Remove autogenerated content from ActiveAdmin

### DIFF
--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -24,4 +24,14 @@ ActiveAdmin.register AdminUser do
     end
     f.actions
   end
+
+  show do
+    attributes_table do
+      row :id
+      row :email
+      row :sign_in_count
+      row :created_at
+      row :updated_at
+    end
+  end
 end


### PR DESCRIPTION
### Description:
#### Avoids showing unnecessary AdminUser attributes (like encrypted password and reset password token) in ActiveAdmin.
![Screen Shot 2020-02-06 at 2 56 00 PM](https://user-images.githubusercontent.com/42643389/73964412-e637f800-48f0-11ea-8a07-59f80b364108.png)
