### PR TITLE
Add yaaf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'rack-cors', '~> 1.0', '>= 1.0.6'
 gem 'sendgrid', '~> 1.2.4'
 gem 'sprockets', '~> 3.7.2'
 gem 'webpacker', '~> 4.2', '>= 4.2.2'
+gem 'yaaf', '~> 0.1'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,6 +437,9 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    yaaf (0.1.1)
+      activemodel (>= 4, < 7)
+      activerecord (>= 4, < 7)
     zeitwerk (2.3.0)
 
 PLATFORMS
@@ -484,9 +487,10 @@ DEPENDENCIES
   uglifier (~> 4.2)
   webmock (~> 3.7, >= 3.7.6)
   webpacker (~> 4.2, >= 4.2.2)
+  yaaf (~> 0.1)
 
 RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This template comes with:
 - [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) adds other testing matchers
 - [Simplecov](https://github.com/colszowka/simplecov) for code coverage
 - [Webmock](https://github.com/bblimke/webmock) for stubbing http requests
+- [YAAF](https://github.com/rootstrap/yaaf) for form objects
 
 ## Optional configuration
 

--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -1,2 +1,9 @@
+# Form objects is a design pattern that will help you build models and
+# keep business validations and callbacks away from the models.
+# To learn more about form objects check out https://github.com/rootstrap/yaaf#links
+#
+# You should inherit from ApplicationForm in order to use form objects,
+# to learn more about using the gem check out https://github.com/rootstrap/yaaf
+
 class ApplicationForm < YAAF::Form
 end

--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -1,0 +1,2 @@
+class ApplicationForm < YAAF::Form
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,14 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
+
+  # Form objects specs
+  config.define_derived_metadata(file_path: Regexp.new('/spec/forms/')) do |metadata|
+    metadata[:type] = :form
+  end
+
+  config.include Shoulda::Matchers::ActiveModel, type: :form
+  config.include Shoulda::Matchers::ActiveRecord, type: :form
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
Why?
- You aren't forced to use it if you don't want.
- If you use it, we believe the codebase could be more maintainable than when using `accepts_nested_attributes_for` or putting creational code in the controller.

You can see more info here https://github.com/rootstrap/yaaf
and sample code here https://rootstrap.github.io/yaaf/
including an example for a JSON API that is our case here https://rootstrap.github.io/yaaf/recipes/json_api.html