### PR TITLE
Make PORO presenter work with ActiveAdmin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rails', '~> 6.0.0'
 
 gem 'active_storage_base64', '~> 1.0.0'
 gem 'activeadmin', '~> 2.4'
+gem 'activeadmin-poro-decorator', '~> 0.2'
 gem 'aws-sdk-s3', '~> 1', require: false
 gem 'bootsnap', '~> 1.4', '>= 1.4.5'
 gem 'delayed_job_active_record', '~> 4.1', '>= 4.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
       sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
       sprockets-es6 (~> 0.9, >= 0.9.2)
+    activeadmin-poro-decorator (0.2.0)
+      rails (>= 4.0.0)
     activejob (6.0.2.2)
       activesupport (= 6.0.2.2)
       globalid (>= 0.3.6)
@@ -425,6 +427,7 @@ PLATFORMS
 DEPENDENCIES
   active_storage_base64 (~> 1.0.0)
   activeadmin (~> 2.4)
+  activeadmin-poro-decorator
   annotate (~> 3.0, >= 3.0.3)
   aws-sdk-s3 (~> 1)
   better_errors (~> 2.5, >= 2.5.1)

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -23,6 +23,15 @@
 #   end
 #
 class BasePresenter
+  include ActiveadminPoroDecorator
+
+  delegate_missing_to :record
+  delegate :to_param, to: :record
+
+  def initialize(record)
+    @record = record
+  end
+
   # Wraps each record in the collection in
   # a presenter
   #
@@ -30,4 +39,8 @@ class BasePresenter
   def self.wrap_collection(collection)
     collection.map { |record| new(record) }
   end
+
+  private
+
+  attr_reader :record
 end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -1,17 +1,7 @@
 class UserPresenter < BasePresenter
-  delegate_missing_to :user
-
-  def initialize(user)
-    @user = user
-  end
-
   def full_name
-    return user.username if user.first_name.blank?
+    return record.username if record.first_name.blank?
 
-    "#{user.first_name} #{user.last_name}"
+    "#{record.first_name} #{record.last_name}"
   end
-
-  private
-
-  attr_reader :user
 end

--- a/config/activeadmin-poro-decorator.yml
+++ b/config/activeadmin-poro-decorator.yml
@@ -1,0 +1,1 @@
+modelname: Presenter


### PR DESCRIPTION
This is a POC of a PORO presenter working with ActiveAdmin. At first I tried to do it without using the gem but it was really really hard. The gem made it work but I think it has some issues for example with pagination, sorting, etc.

Seems like initially ActiveAdmin wanted to support different presenter/decorator implementations but at some point they decided to stick with Draper and not officially support any other alternative. https://github.com/activeadmin/activeadmin/issues/3600#issuecomment-62959836 

I think the presenter pattern is necessary in ActiveAdmin to prevent presentational methods leak into the models, so that leads us to the question, do we feel confident going against the path that ActiveAdmin has taken? Should we replace Draper for PORO presenters? Should we use a gem which last update was on 2015? Is it worth it?