### PR TITLE
Move tests down in the pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,6 @@ jobs:
           name: I18n Health
           command: bundle exec i18n-tasks health
 
-      - run:
-          name: run tests
-          command: RAILS_ENV=test bundle exec rspec
-
       # run code_analysis!
       - run:
           name: run code analysis
@@ -51,6 +47,11 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+
+      # run tests
+      - run:
+          name: run tests
+          command: RAILS_ENV=test bundle exec rspec
 
       # run codeclimate!
       - run:


### PR DESCRIPTION
#### Board:
* N/A
---
#### Description:
* This PR moves the `code_analysis` task before running the tests in the circleci pipeline. This is because the `code_analysis` takes less time to execute than the tests. This can potentially save computing time in circleci to allow other workflows to run.
