### PR TITLE
fix models auto annotation task

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -2,9 +2,11 @@
 #
 # Table name: settings
 #
-#  id    :integer          not null, primary key
-#  key   :string
-#  value :string
+#  id         :bigint           not null, primary key
+#  key        :string           not null
+#  value      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 
 class Setting < ApplicationRecord

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,6 @@
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
 #  allow_password_change  :boolean          default(FALSE)
-#  remember_created_at    :datetime
 #  sign_in_count          :integer          default(0), not null
 #  current_sign_in_at     :datetime
 #  last_sign_in_at        :datetime

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,6 +71,8 @@ ActiveRecord::Schema.define(version: 2020_01_28_183708) do
   create_table "settings", force: :cascade do |t|
     t.string "key", null: false
     t.string "value"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", id: :serial, force: :cascade do |t|

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -13,6 +13,7 @@ if Rails.env.development?
       'position_in_factory' => 'before',
       'show_indexes' => 'true',
       'simple_indexes' => 'false',
+      'models' => 'true',
       'model_dir' => 'app/models',
       'include_version' => 'false',
       'require' => '',

--- a/spec/factories/settings.rb
+++ b/spec/factories/settings.rb
@@ -2,9 +2,11 @@
 #
 # Table name: settings
 #
-#  id    :integer          not null, primary key
-#  key   :string
-#  value :string
+#  id         :bigint           not null, primary key
+#  key        :string           not null
+#  value      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 
 FactoryBot.define do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,7 +8,6 @@
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
 #  allow_password_change  :boolean          default(FALSE)
-#  remember_created_at    :datetime
 #  sign_in_count          :integer          default(0), not null
 #  current_sign_in_at     :datetime
 #  last_sign_in_at        :datetime

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,7 +8,6 @@
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
 #  allow_password_change  :boolean          default(FALSE)
-#  remember_created_at    :datetime
 #  sign_in_count          :integer          default(0), not null
 #  current_sign_in_at     :datetime
 #  last_sign_in_at        :datetime


### PR DESCRIPTION
#### Description:
- This PR fixes `auto_annotate_models` task. It was not triggering after executing `bin/rails db:migrate`. Now it does
- Adds settings model timestamp to schema. (Seems like `db:migrate` wasn't run previously)
- Fix annotations