### PR TITLE
Remove lib directory from the autoload paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module App
     # the framework and any gems in your application.
     config.load_defaults 6.0
 
-    config.autoload_paths += %W[#{config.root}/lib]
+    config.add_autoload_paths_to_load_path = false
 
     ActionMailer::Base.smtp_settings = {
       address: 'smtp.sendgrid.net',


### PR DESCRIPTION
#### Description:
- Removed `{project_root}/lib` directory from the autoload paths

We can have a `{project_root}/app/lib` folder for the `.rb` files.
Autoloading, reloading and eagerloading work by default using zeitwerk mode, so there's no need to extend `autoload_paths`.

Also, this is the recommended way according to [this comment](https://github.com/rails/rails/issues/37835#issuecomment-560075069).

- opt-out autoloadable files from `$LOAD_PATH`

> Autoload paths are added to `$LOAD_PATH` by default. However, Zeitwerk uses absolute file names internally, and your application should not issue require calls for autoloadable files. 


Reference: [here](https://edgeguides.rubyonrails.org/autoloading_and_reloading_constants.html#%24load-path)

---
#### Notes:

For more context, Zeitwerk mode explained [here](https://edgeguides.rubyonrails.org/autoloading_and_reloading_constants.html)

---
#### Tasks:

---
#### Risk:

---
