### PR TITLE
Check Content-Type header only when a payload is sent

### DIFF
--- a/app/controllers/api/concerns/act_as_api_request.rb
+++ b/app/controllers/api/concerns/act_as_api_request.rb
@@ -10,8 +10,7 @@ module Api
       end
 
       def check_json_request
-        return unless request_with_body?
-        return if request_content_type.match?(/json/)
+        return if !request_with_body? || request_content_type.match?(/json/)
 
         render json: { error: I18n.t('api.errors.invalid_content_type') }, status: :not_acceptable
       end

--- a/app/controllers/api/concerns/act_as_api_request.rb
+++ b/app/controllers/api/concerns/act_as_api_request.rb
@@ -10,7 +10,8 @@ module Api
       end
 
       def check_json_request
-        return if request_content_type&.match?(/json/)
+        return unless request_with_body?
+        return if request_content_type.match?(/json/)
 
         render json: { error: I18n.t('api.errors.invalid_content_type') }, status: :not_acceptable
       end
@@ -28,8 +29,14 @@ module Api
         render json: response, status: status
       end
 
+      private
+
       def request_content_type
-        request.content_type
+        request.content_type || ''
+      end
+
+      def request_with_body?
+        request.post? || request.put? || request.patch?
       end
     end
   end

--- a/spec/requests/api/v1/status_spec.rb
+++ b/spec/requests/api/v1/status_spec.rb
@@ -1,25 +1,15 @@
 require 'rails_helper'
 
 describe 'GET api/v1/status', type: :request do
-  context 'with invalid content type' do
-    it 'returns status 406 not acceptable' do
-      get api_v1_status_path
-
-      expect(response).to have_http_status(:not_acceptable)
-    end
+  before do
+    get api_v1_status_path, as: :json
   end
 
-  context 'with valid content type' do
-    before do
-      get api_v1_status_path, as: :json
-    end
+  it 'returns status 200 ok' do
+    expect(response).to be_successful
+  end
 
-    it 'returns status 200 ok' do
-      expect(response).to be_successful
-    end
-
-    it 'returns the api status' do
-      expect(json['online']).to be true
-    end
+  it 'returns the api status' do
+    expect(json['online']).to be true
   end
 end


### PR DESCRIPTION
Clients use the Content-Type header to tell the server what type of data
has been sent. Hence there is no need for the server to disallow GET or
HEAD requests. More info on how the Content-Type header is/should-be used for
requests [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#:~:text=the%20client%20tells%20the%20server%20what%20type%20of%20data%20is%20actually%20sent) and [here](https://tools.ietf.org/html/rfc7231#section-3.1.1.5).

Updated status_spec to match this behavior.