### PR TITLE
Using Rails in api_only mode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,7 @@ Layout/LineLength:
 Rails/Delegate:
   Exclude:
     - app/controllers/api/concerns/act_as_api_request.rb
+
+Rails/LexicallyScopedActionFilter:
+  Exclude:
+    - app/controllers/api/v1/api_controller.rb

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,14 +1,14 @@
 module Api
   module V1
-    class ApiController < ApplicationController
-      include Api::Concerns::ActAsApiRequest
+    class ApiController < ActionController::API
+      include Pundit
       include DeviseTokenAuth::Concerns::SetUserByToken
+
+      after_action :verify_authorized, except: :index
+      after_action :verify_policy_scoped, only: :index
 
       before_action :authenticate_user!, except: :status
       skip_after_action :verify_authorized, only: :status
-
-      layout false
-      respond_to :json
 
       rescue_from ActiveRecord::RecordNotFound,        with: :render_not_found
       rescue_from ActiveRecord::RecordInvalid,         with: :render_record_invalid

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Pundit
+
   after_action :verify_authorized,
                except: :index,
                unless: -> { :devise_controller? || :active_admin_controller? }
@@ -7,7 +8,6 @@ class ApplicationController < ActionController::Base
                only: :index,
                unless: -> { :devise_controller? || :active_admin_controller? }
   # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
   def active_admin_controller?

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,15 @@ module App
       g.test_framework :rspec
       g.fixture_replacement :factory_bot, dir: 'spec/factories'
     end
+
+    # Only loads a smaller set of middleware suitable for API only apps.
+    # Middleware like session, flash, cookies can be added back manually.
+    # Skip views, helpers and assets when generating a new resource.
+    config.api_only = true
+
+    # ActiveAdmin needs the following middlewares to work properly.
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
+    config.middleware.use ActionDispatch::Flash
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,4 +75,6 @@ Rails.application.configure do
     Bullet.rails_logger = true
     Bullet.add_footer = true
   end
+
+  config.debug_exception_response_format = :default
 end

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -6,7 +6,7 @@ describe 'GET api/v1/settings/must_update', type: :request do
       device_version: '1.0'
     }
   end
-  subject { get must_update_api_v1_settings_path, params: params, as: :json }
+  subject { get must_update_api_v1_settings_path, params: params }
 
   context 'with correct settings' do
     let!(:setting_version) { create(:setting_version) }


### PR DESCRIPTION
Api only apps won't need all controller modules used in normal applications,
for instance: ViewPaths, Layouts, Templates, and so on. Moreover, api only apps
won't need all middlewares used in normal applications, for instance:
MethodOverride (used to override the HTTP verb when passing a hidden
field in form submissions), ContentSecurityPolicy (which is a browser-only thing), and so.

One consideration: Devise controllers will always
inherit from ApplicationController, hence we still need to use the
ActAsApiRequest concern in Devise controllers. This is because Devise is shared
between the API-only app and the admin panel.

_Branched off from #250_