### PR TITLE
Enhancement: set CC_TEST_REPORTER_ID as a env key in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
 version: 2
 jobs:
   build:
-    environment:
-      # You must replace the CC_TEST_REPORTER_ID with the one of your project
-      CC_TEST_REPORTER_ID: 89b5ee3c59b8aeeb88ddc2f5469410dc9e0fb800ec4346a54a759bfc4eccb6b3
     docker:
       - image: circleci/ruby:2.7.1-node-browsers
       - image: circleci/postgres:9.4

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ With `rake code_analysis` you can run the code analysis tool, you can omit rules
 ## Configuring Code Climate
 1. After adding the project to CC, go to `Repo Settings`
 1. On the `Test Coverage` tab, copy the `Test Reporter ID`
-1. Replace the current value of `CC_TEST_REPORTER_ID` on the `config.yml file (.circleci/config.yml)` with the one you copied from CC
+1. Set the current value of `CC_TEST_REPORTER_ID` in the [circle-ci project env variables](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)
 
 ## Code Owners
 


### PR DESCRIPTION
**In this PR:**
 - [x] Set CC_TEST_REPORTER_ID as a env key in CircleCI

**Description:**
As @pablanco suggested, we could be adding this key to the ENV variables of the project.
This will not only improve security, but also when cloning this repository, if the key is not set, then the CI build will fail. So in a way we are enforcing the devs to set their own key