### PR TITLE
Enhancement: check if annotate was run in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,3 +86,11 @@ jobs:
             chmod +x ./cc-test-reporter
             ./cc-test-reporter before-build
             ./cc-test-reporter after-build
+
+      - run:
+          name: Check for missing annotations
+          command: RAILS_ENV=test bundle exec annotate
+      
+      # Check if running annotate changed any file
+      - check_untracked_files:
+          path: "app/ spec/"


### PR DESCRIPTION
I have found PRs that change the annotations on files that are not necessarily changed in that particular PR, in fact, I have made the mistake of uploading pull requests without running the annotate 😞 . So in order to prevent that kind of thing happen, I extended the check of changed files to see if running annotate changed any (which shouldn't).

 FYI: I placed this check after all the other ones as the build is less common that someone forgot to run `annotate` than to have failing tests or have code style errors.


Added Time to the build: `1 second`
<img width="1120" alt="Screen Shot 2020-09-23 at 18 01 08" src="https://user-images.githubusercontent.com/50113670/94069363-d8bf7780-fdc6-11ea-800c-5b8c743e0f3e.png">
