### PR TITLE
Change apiary link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This template comes with:
 
 ## Api Docs
 
-http://docs.railsapibase.apiary.io
+https://railsapibasers.docs.apiary.io/
 
 With [Rspec API Doc Generator](https://github.com/zipmark/rspec_api_documentation) you can generate the docs after writing the acceptance specs.
 

--- a/config/initializers/rspec_api_documentation.rb
+++ b/config/initializers/rspec_api_documentation.rb
@@ -54,7 +54,7 @@ unless Rails.env.production?
     # config.keep_source_order = false
 
     # Change the name of the API on index pages
-    config.api_name = 'Rails API Template'
+    config.api_name = 'Rails API Base'
 
     # Change the description of the API on index pages
     # config.api_explanation = "API Description"


### PR DESCRIPTION
#### Description:

This PR changes the _apiary_ link at `README.md` because was outdated and was not using the docs generated in #269 

