### PR TITLE
Enhancement: pass logger parameters as blocks

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -27,7 +27,7 @@ module Api
         # To properly handle RecordNotFound errors in views
         return render_not_found(exception) if exception.cause.is_a?(ActiveRecord::RecordNotFound)
 
-        logger.error(exception) # Report to your error managment tool here
+        logger.error { exception } # Report to your error managment tool here
 
         return if performed?
 
@@ -35,17 +35,17 @@ module Api
       end
 
       def render_not_found(exception)
-        logger.info(exception) # for logging
+        logger.info { exception } # for logging
         render json: { error: I18n.t('api.errors.not_found') }, status: :not_found
       end
 
       def render_record_invalid(exception)
-        logger.info(exception) # for logging
+        logger.info { exception } # for logging
         render json: { errors: exception.record.errors.as_json }, status: :bad_request
       end
 
       def render_parameter_missing(exception)
-        logger.info(exception) # for logging
+        logger.info { exception } # for logging
         render json: { error: I18n.t('api.errors.missing_param') }, status: :unprocessable_entity
       end
     end


### PR DESCRIPTION
#### Description:
In this PR it is changed the way parameters are passed to the logger. The reason behind this can be found [here](https://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance).

```

Logging will always have a small impact on the performance of your Rails app, particularly when logging to disk. Additionally, there are a few subtleties:

Using the :debug level will have a greater performance penalty than :fatal, as a far greater number of strings are being evaluated and written to the log output (e.g. disk).

Another potential pitfall is too many calls to Logger in your code:

logger.debug "Person attributes hash: #{@person.attributes.inspect}"

In the above example, there will be a performance impact even if the allowed output level doesn't include debug. The reason is that Ruby has to evaluate these strings, which includes instantiating the somewhat heavy String object and interpolating the variables.

Therefore, it's recommended to pass blocks to the logger methods, as these are only evaluated if the output level is the same as — or included in — the allowed level (i.e. lazy loading). The same code rewritten would be:


logger.debug {"Person attributes hash: #{@person.attributes.inspect}"}

The contents of the block, and therefore the string interpolation, are only evaluated if debug is enabled. This performance savings are only really noticeable with large amounts of logging, but it's a good practice to employ.
```
