### PR TITLE
ApplicationCable

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+  end
+end


### PR DESCRIPTION
#### Description:

Rails generates these files by default. (https://guides.rubyonrails.org/action_cable_overview.html#channels)
I think we should keep them, as some gems could expect you to have them.

These files were removed in this PR(https://github.com/rootstrap/rails_api_base/pull/127)