### PR TITLE
Remove Set-cookie header in API response

### DIFF
--- a/app/controllers/api/concerns/act_as_api_request.rb
+++ b/app/controllers/api/concerns/act_as_api_request.rb
@@ -4,7 +4,6 @@ module Api
       extend ActiveSupport::Concern
 
       included do
-        skip_before_action :verify_authenticity_token
         before_action :skip_session_storage
         before_action :check_json_request
       end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class ApiController < ActionController::API
+      include Api::Concerns::ActAsApiRequest
       include Pundit
       include DeviseTokenAuth::Concerns::SetUserByToken
 

--- a/spec/requests/api/v1/users/show_spec.rb
+++ b/spec/requests/api/v1/users/show_spec.rb
@@ -2,6 +2,12 @@ describe 'GET api/v1/users/:id', type: :request do
   let(:user) { create(:user) }
   subject { get api_v1_user_path, headers: auth_headers, as: :json }
 
+
+  it 'there must not be a Set-Cookie in Header' do
+    subject
+    expect(response.headers.keys).not_to include("Set-Cookie")
+  end
+
   it 'returns success' do
     subject
     expect(response).to have_http_status(:success)
@@ -9,7 +15,6 @@ describe 'GET api/v1/users/:id', type: :request do
 
   it "returns the logged in user's data" do
     subject
-
     expect(json[:user][:id]).to eq(user.id)
     expect(json[:user][:name]).to eq(user.full_name)
   end


### PR DESCRIPTION
For each successful response by API (skipping sessions, password, and sign controllers) a 'Set-cookie' value was sent in the header response .

For subsequent requests if we used the value 'Set-cookie' in the header, was not necessary use the tokens for authentication, I mean you have two ways to access by token or cookie in header.

This pull request tries to ensure that you will only have access to the API by token

#### See in how it worked:

> Step 1 - Sign In:

````
curl -i --location --request POST 'http://localhost:3000/api/v1/users/sign_in' \
--header 'Content-Type: application/json' \
--data-raw '{
    "user": {
        "email": "jeroig@rootstrap.com",
        "password": "Test1234"
    }
}'
````
Response: (relevant data)
````
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
access-token: OxKk7Rb1DU5wuhpDnt2QXg
token-type: Bearer
client: 4rq-aphrcVbBqDBBMkh25Q
expiry: 1679170722
uid: jeroig@rootstrap.com
````
- - -

> Step 2
````
curl -i --location --request GET 'http://localhost:3000/api/v1/user' \
--header 'Access-Token: OxKk7Rb1DU5wuhpDnt2QXg' \
--header 'token-type: Bearer' \
--header 'client: 4rq-aphrcVbBqDBBMkh25Q' \
--header 'expiry: 1679170722' \
--header 'uid: jeroig@rootstrap.com'
````
Response: (relevant data)
````
HTTP/1.1 200 OK
....
....
....
Set-Cookie: _session_id={{string_too_long}}; path=/; HttpOnly
....
....
....
````

- - -
> Step 3
 ````
curl --location --request GET 'http://localhost:3000/api/v1/user' \
--header 'Cookie: _session_id={{string_too_long}}'
````
Response: Ok
````
HTTP/1.1 200 OK
{"user":{"id":5,"email":"jeroig@rootstrap.com","name":"Juan1 Roig2","username":"jeroig"}}
````
