### PR TITLE
Change devise initializer setting to prevent storing jwt sessions

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -75,7 +75,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [:http_auth]
+  config.skip_session_storage =  %i[http_auth jwt]
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX


### PR DESCRIPTION
#### Issue:
[Auth & Sign Out](https://github.com/rootstrap/rails_api_base/issues/293)
---
#### Description:
Sign in and then immediately sign out should get a success response if the sing in was a success. However getting a 404 user not found or logged in.

If i sign up and then immediately sign out all is fine. Only on sign in
---
#### Current behavior
API response is 404
{
    "error": "User was not found or was not logged in."
}
---
#### Applied solution
config.skip_session_storage setting in devise.rb initializer was changed from [:http_auth]  to %i[http_auth jwt]
With this option devise skips checking in the session for a jwt token when destroying a session in the sessions controller.
API response is 200 ok
{
    "success": true
} 