### PR TITLE
Update Readme to include database configuration with docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This template comes with:
 ## How to use with docker
 
 1. Have `docker` and `docker-compose` installed (You can check this by doing `docker -v` and `docker-compose -v`)
-2. Modify the following lines in the `database.yml` file:
+1. Modify the following lines in the `database.yml` file:
   ``` yaml
   default: &default
     adapter: postgresql
@@ -51,13 +51,17 @@ This template comes with:
     host: db
     port: 5432
   ```
-3. Generate a secret key for the app by running `docker-compose run --rm --entrypoint="" web rake secret`, copy it and add it in your environment variables.
-4. Run `docker-compose run --rm --entrypoint="" web rails db:create db:migrate`.
+1. Generate a secret key for the app by running `docker-compose run --rm --entrypoint="" web rake secret`, copy it and add it in your environment variables.
+1. Update the default database configuration in the `config/database.yml` file to point to the `docker-compose` database:
+   1. Set `username: postgres`
+   1. Set `password: postgres`
+   1. Set `host: db`
+1. Run `docker-compose run --rm --entrypoint="" web rails db:create db:migrate`.
    1. (Optional) Seed the database with an AdminUser for use with ActiveAdmin by running `docker-compose run --rm --entrypoint="" web rails db:seed`. The credentials for this user are: email: `admin@example.com` ; password: `password`.
-5. (Optional) If you want to deny access to the database from outside of the `docker-compose` network, remove the `ports` key in the `docker-compose.yml` from the `db` service.
-6. (Optional) Run the tests to make sure everything is working with: `docker-compose run --rm --entrypoint="" web rspec .`.
-7. Run the application with `docker-compose up`.
-8. You can now try your REST services!
+1. (Optional) If you want to deny access to the database from outside of the `docker-compose` network, remove the `ports` key in the `docker-compose.yml` from the `db` service.
+1. (Optional) Run the tests to make sure everything is working with: `docker-compose run --rm --entrypoint="" web rspec .`.
+1. Run the application with `docker-compose up`.
+1. You can now try your REST services!
 
 ## Gems
 


### PR DESCRIPTION
Right now when configuring the app with the default **DOCKER** credentials results in an error:
```
could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
```

Because we should point to `db` host in the `database.yml`

Also, postgres now requires the default username and password, so right now the result is:

```
fe_sendauth: no password supplied
Couldn't create 'a-price-for_development' database. Please check your configuration.
rails aborted!
PG::ConnectionBad: fe_sendauth: no password supplied
```

The fix for that is to add `postgres` and `postgres` as `username/password` for the DB

