### PR TITLE
Fix/forgery protection on api calls

### DIFF
--- a/app/controllers/api/concerns/act_as_api_request.rb
+++ b/app/controllers/api/concerns/act_as_api_request.rb
@@ -36,6 +36,10 @@ module Api
       def request_with_body?
         request.post? || request.put? || request.patch?
       end
+
+      def json_request?
+        request.format.json?
+      end
     end
   end
 end

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class PasswordsController < DeviseTokenAuth::PasswordsController
-      protect_from_forgery with: :exception
+      protect_from_forgery with: :exception, unless: :json_request?
       include Api::Concerns::ActAsApiRequest
       skip_before_action :check_json_request, on: :edit
     end

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class RegistrationsController < DeviseTokenAuth::RegistrationsController
-      protect_from_forgery with: :exception
+      protect_from_forgery with: :exception, unless: :json_request?
       include Api::Concerns::ActAsApiRequest
 
       private

--- a/spec/requests/api/v1/passwords/create_spec.rb
+++ b/spec/requests/api/v1/passwords/create_spec.rb
@@ -1,35 +1,39 @@
 describe 'POST api/v1/users/password', type: :request do
+  subject { post user_password_path, params: params, as: :json }
+
   let!(:user) { create(:user, password: 'mypass123') }
 
   context 'with valid params' do
     let(:params) { { email: user.email } }
 
+    it_behaves_like 'does not check authenticity token'
+    it_behaves_like 'there must not be a Set-Cookie in Header'
+
     it 'returns a successful response' do
-      post user_password_path, params: params, as: :json
+      subject
       expect(response).to have_http_status(:success)
     end
 
     it 'returns the user email' do
-      post user_password_path, params: params, as: :json
+      subject
       expect(json[:message]).to match(/#{user.email}/)
     end
 
     it 'sends an email' do
-      expect { post user_password_path, params: params, as: :json }
-        .to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
   end
 
   context 'with invalid params' do
+    let(:params) { { email: 'notvalid@example.com' } }
+
     it 'does not return a successful response' do
-      post user_password_path, params: { email: 'notvalid@example.com' }, as: :json
+      subject
       expect(response.status).to eq(404)
     end
 
     it 'does not send an email' do
-      expect {
-        post user_password_path, params: { email: 'notvalid@example.com' }, as: :json
-      }.to change { ActionMailer::Base.deliveries.count }.by(0)
+      expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(0)
     end
   end
 end

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -3,6 +3,8 @@ describe 'POST api/v1/users/', type: :request do
   let(:failed_response) { 422 }
 
   describe 'POST create' do
+    subject { post user_registration_path, params: params, as: :json }
+
     let(:username)              { 'test' }
     let(:email)                 { 'test@test.com' }
     let(:password)              { '12345678' }
@@ -23,20 +25,20 @@ describe 'POST api/v1/users/', type: :request do
       }
     end
 
-    it 'returns a successful response' do
-      post user_registration_path, params: params, as: :json
+    it_behaves_like 'does not check authenticity token'
+    it_behaves_like 'there must not be a Set-Cookie in Header'
 
+    it 'returns a successful response' do
+      subject
       expect(response).to have_http_status(:success)
     end
 
     it 'creates the user' do
-      expect {
-        post user_registration_path, params: params, as: :json
-      }.to change(User, :count).by(1)
+      expect { subject }.to change(User, :count).by(1)
     end
 
     it 'returns the user' do
-      post user_registration_path, params: params, as: :json
+      subject
 
       expect(json[:user][:id]).to eq(user.id)
       expect(json[:user][:email]).to eq(user.email)
@@ -51,14 +53,11 @@ describe 'POST api/v1/users/', type: :request do
       let(:email) { 'invalid_email' }
 
       it 'does not create a user' do
-        expect {
-          post user_registration_path, params: params, as: :json
-        }.not_to change { User.count }
+        expect { subject }.not_to change { User.count }
       end
 
       it 'does not return a successful response' do
-        post user_registration_path, params: params, as: :json
-
+        subject
         expect(response.status).to eq(failed_response)
       end
     end
@@ -69,14 +68,12 @@ describe 'POST api/v1/users/', type: :request do
       let(:new_user)              { User.find_by(email: email) }
 
       it 'does not create a user' do
-        post user_registration_path, params: params, as: :json
-
+        subject
         expect(new_user).to be_nil
       end
 
       it 'does not return a successful response' do
-        post user_registration_path, params: params, as: :json
-
+        subject
         expect(response.status).to eq(failed_response)
       end
     end
@@ -87,14 +84,12 @@ describe 'POST api/v1/users/', type: :request do
       let(:new_user)              { User.find_by(email: email) }
 
       it 'does not create a user' do
-        post user_registration_path, params: params, as: :json
-
+        subject
         expect(new_user).to be_nil
       end
 
       it 'does not return a successful response' do
-        post user_registration_path, params: params, as: :json
-
+        subject
         expect(response.status).to eq(failed_response)
       end
     end

--- a/spec/requests/api/v1/users/show_spec.rb
+++ b/spec/requests/api/v1/users/show_spec.rb
@@ -2,10 +2,7 @@ describe 'GET api/v1/users/:id', type: :request do
   let(:user) { create(:user) }
   subject { get api_v1_user_path, headers: auth_headers, as: :json }
 
-  it 'there must not be a Set-Cookie in Header' do
-    subject
-    expect(response.headers.keys).not_to include('Set-Cookie')
-  end
+  it_behaves_like 'there must not be a Set-Cookie in Header'
 
   it 'returns success' do
     subject

--- a/spec/support/shared_examples/requests/cookie_not_present_spec.rb
+++ b/spec/support/shared_examples/requests/cookie_not_present_spec.rb
@@ -1,0 +1,6 @@
+RSpec.shared_examples 'there must not be a Set-Cookie in Header' do
+  it 'does not return a Set-Cookie Header' do
+    subject
+    expect(response.headers.keys).not_to include('Set-Cookie')
+  end
+end

--- a/spec/support/shared_examples/requests/forgery_protection_disabled_spec.rb
+++ b/spec/support/shared_examples/requests/forgery_protection_disabled_spec.rb
@@ -1,0 +1,14 @@
+RSpec.shared_examples 'does not check authenticity token' do
+  context 'with forgery protection enabled' do
+    before do
+      ActionController::Base.allow_forgery_protection = true
+    end
+    after do
+      ActionController::Base.allow_forgery_protection = false
+    end
+
+    it 'does not raise an error' do
+      expect { subject }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
#### Board:
N/A

---
#### Description:
Error `ActiveController::InvalidAuthenticityToken` was raised on API calls related to Devise controllers, for example on user registration (`POST /api/v1/users`). Added `unless: :json_request?` condition on `protect_from_forgery` to prevent that.

---
#### Notes:

Specs weren't failing before because forgery protection is disabled by default on test environment. I created a shared example that enables it and calls the subject, expecting to not raise an error.
Also added a shared example to check that Set-Cookie is not returned, and made a refactor on some spec files to reduce repeating code.

