### PR TITLE
Update instructions for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM ruby:2.7.2
 
-RUN apt-get update -qq && \
-    apt-get install -y build-essential libssl-dev nodejs libpq-dev less vim nano libsasl2-dev
-
+RUN apt-get update -qq
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt update && apt install yarn
+
+RUN apt-get update -qq
+RUN apt-get install -y git-core zlib1g-dev build-essential libssl-dev libreadline-dev libyaml-dev \
+    libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common \
+    libffi-dev nodejs libpq-dev less vim nano libsasl2-dev yarn
 
 ENV WORK_ROOT /src
 ENV APP_HOME $WORK_ROOT/myapp/

--- a/README.md
+++ b/README.md
@@ -31,37 +31,34 @@ This template comes with:
 ## How to use
 
 1. Clone this repo
-1. Install PostgreSQL in case you don't have it
-1. Run `bootstrap.sh` with the name of your your project like `./bootstrap.sh my_awesome_project`
-1. `rspec` and make sure all tests pass
-1. `rails s`
-1. You can now try your REST services!
+2. Install PostgreSQL in case you don't have it
+3. Run `bootstrap.sh` with the name of your your project like `./bootstrap.sh my_awesome_project`
+4. `rspec` and make sure all tests pass
+5. `rails s`
+6. You can now try your REST services!
 
 ## How to use with docker
 
 1. Have `docker` and `docker-compose` installed (You can check this by doing `docker -v` and `docker-compose -v`)
-1. Modify the following lines in the `database.yml` file:
-  ``` yaml
-  default: &default
-    adapter: postgresql
-    encoding: unicode
-    pool: 5
-    username: postgres
-    password: postgres
-    host: db
-    port: 5432
-  ```
-1. Generate a secret key for the app by running `docker-compose run --rm --entrypoint="" web rake secret`, copy it and add it in your environment variables.
-1. Update the default database configuration in the `config/database.yml` file to point to the `docker-compose` database:
-   1. Set `username: postgres`
-   1. Set `password: postgres`
-   1. Set `host: db`
-1. Run `docker-compose run --rm --entrypoint="" web rails db:create db:migrate`.
-   1. (Optional) Seed the database with an AdminUser for use with ActiveAdmin by running `docker-compose run --rm --entrypoint="" web rails db:seed`. The credentials for this user are: email: `admin@example.com` ; password: `password`.
-1. (Optional) If you want to deny access to the database from outside of the `docker-compose` network, remove the `ports` key in the `docker-compose.yml` from the `db` service.
-1. (Optional) Run the tests to make sure everything is working with: `docker-compose run --rm --entrypoint="" web rspec .`.
-1. Run the application with `docker-compose up`.
-1. You can now try your REST services!
+2. Modify the following lines in the `config/database.yml` file:
+      ``` yaml
+      default: &default
+        adapter: postgresql
+        encoding: unicode
+        pool: 5
+        username: postgres
+        password: postgres
+        host: db
+        port: 5432
+      ```
+3. Generate a secret key for the app by running `docker-compose run --rm --entrypoint="" web rake secret`, copy it and add it in your environment variables.
+4. Add secret key to `secret_key_base` key by running `EDITOR='code --wait' rails credentials:edit`
+5. Run `docker-compose run --rm --entrypoint="" web rails db:create db:migrate`.
+    1. (Optional) Seed the database with an AdminUser for use with ActiveAdmin by running `docker-compose run --rm --entrypoint="" web rails db:seed`. The credentials for this user are: email: `admin@example.com` ; password: `password`.
+6. (Optional) If you want to deny access to the database from outside of the `docker-compose` network, remove the `ports` key in the `docker-compose.yml` from the `db` service.
+7. (Optional) Run the tests to make sure everything is working with: `docker-compose run --rm --entrypoint="" web rspec .`.
+8. Run the application with `docker-compose up`.
+9. You can now try your REST services!
 
 ## Gems
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,8 @@
-AdminUser.create!(email: 'admin@example.com', password: 'password') if Rails.env.development?
-Setting.create_or_find_by!(key: 'min_version', value: '0.0')
+if Rails.env.development?
+  AdminUser.where(email: 'admin@example.com')
+           .first_or_create!(email: 'admin@example.com', password: 'password')
+  Rails.logger.info('Admin user created.')
+end
+
+Setting.where(key: 'min_version').first_or_create!(key: 'min_version', value: '0.0')
+Rails.logger.info('Added min version to Settings.')


### PR DESCRIPTION
After updating the codebase to Rails 6.1.4, it became necessary to install the NodeJS 12 instead of 10 in Docker container.