### PR TITLE
Update CI badge in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rails API Template
 
-[![CircleCI](https://circleci.com/gh/rootstrap/rails_api_base.svg?style=svg)](https://circleci.com/gh/rootstrap/rails_api_base)
+[![Github Actions CI](https://github.com/rootstrap/rails_api_base/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/rootstrap/rails_api_base/actions)
 [![Code Climate](https://codeclimate.com/github/rootstrap/rails_api_base/badges/gpa.svg)](https://codeclimate.com/github/rootstrap/rails_api_base)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/63de7f82c79f5fe82f46/test_coverage)](https://codeclimate.com/github/rootstrap/rails_api_base/test_coverage)
 


### PR DESCRIPTION
#### Description:
* Updates the CI result badge shown in README.md, since we migrated from CircleCI to a GA CI workflow
* The new badge redirects to the `Actions` tab
---
#### Notes:
* See [badges for GA workflows here](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge)
---
#### Tasks:
- [x] Update CI badge
---
#### Preview:

New:
<img width="409" alt="imagen" src="https://user-images.githubusercontent.com/80283482/165802635-1902205b-786d-4b63-84dc-6bc2d67473ed.png">

Old:
<img width="378" alt="imagen" src="https://user-images.githubusercontent.com/80283482/165802699-115f6492-82a3-4030-8eb4-c38d7908440c.png">

