### PR TITLE
Fix typos on RSpec gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This template comes with:
   - Reset password
   - Get and update user profile
 - Administration panel for users
-- Rspec tests
+- RSpec tests
 - Code quality tools
 - API documentation following https://apiblueprint.org/
 - Docker support
@@ -90,7 +90,7 @@ To illustrate, `bin/rails console` will run the console in the docker container 
 - [Rails Best Practices](https://github.com/flyerhzm/rails_best_practices) for rails linting
 - [Reek](https://github.com/troessner/reek) for ruby linting
 - [RSpec](https://github.com/rspec/rspec) for testing
-- [Rspec API Doc Generator](https://github.com/zipmark/rspec_api_documentation) for API documentation
+- [RSpec API Doc Generator](https://github.com/zipmark/rspec_api_documentation) for API documentation
 - [Rubocop](https://github.com/bbatsov/rubocop/) for ruby linting
 - [Sendgrid](https://github.com/stephenb/sendgrid) for sending mails
 - [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) adds other testing matchers
@@ -108,7 +108,7 @@ To illustrate, `bin/rails console` will run the console in the docker container 
 
 https://railsapibasers.docs.apiary.io/
 
-With [Rspec API Doc Generator](https://github.com/zipmark/rspec_api_documentation) you can generate the docs after writing the acceptance specs.
+With [RSpec API Doc Generator](https://github.com/zipmark/rspec_api_documentation) you can generate the docs after writing the acceptance specs.
 
 Just run:
 


### PR DESCRIPTION
#### Board:
* Ticket: NO TICKET
---
#### Description:

Just fixing gem name

---
#### Risk:
* None