### PR TITLE
Add env to the rails console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ config/master.key
 # Ignore byebug history
 .byebug_history
 
+# Ignore irb history
+.irb_history
+
 /node_modules
 /yarn-error.log
 yarn-debug.log*

--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,16 @@
+# Add color coding based on Rails environment for safety
+if defined?(Rails)
+  banner = if Rails.env.production?
+             "\e[41;97;1m #{Rails.env} \e[0m "
+           else
+             "\e[42;97;1m #{Rails.env} \e[0m "
+           end
+
+  # Build a custom prompt
+  IRB.conf[:PROMPT][:CUSTOM] = IRB.conf[:PROMPT][:DEFAULT].merge(
+    PROMPT_I: banner + IRB.conf[:PROMPT][:DEFAULT][:PROMPT_I]
+  )
+
+  # Use custom prompt by default
+  IRB.conf[:PROMPT_MODE] = :CUSTOM
+end

--- a/.irbrc
+++ b/.irbrc
@@ -1,10 +1,7 @@
 # Add color coding based on Rails environment for safety
 if defined?(Rails)
-  banner = if Rails.env.production?
-             "\e[41;97;1m #{Rails.env} \e[0m "
-           else
-             "\e[42;97;1m #{Rails.env} \e[0m "
-           end
+  banner_color = Rails.env.production? ? 41 : 42
+  banner = "\e[#{banner_color};97;1m #{Rails.env} \e[0m "
 
   # Build a custom prompt
   IRB.conf[:PROMPT][:CUSTOM] = IRB.conf[:PROMPT][:DEFAULT].merge(

--- a/.pryrc
+++ b/.pryrc
@@ -1,6 +1,18 @@
+# Add command aliases
 if defined?(PryByebug)
   Pry.commands.alias_command 'c', 'continue'
   Pry.commands.alias_command 's', 'step'
   Pry.commands.alias_command 'n', 'next'
   Pry.commands.alias_command 'f', 'finish'
+end
+
+# Add color coding based on Rails environment for safety
+if defined?(Rails) && defined?(Pry)
+  banner = if Rails.env.production?
+             "\e[41;97;1m #{Rails.env} \e[0m "
+           else
+             "\e[42;97;1m #{Rails.env} \e[0m "
+           end
+
+  Pry.config.prompt_name = banner
 end

--- a/.pryrc
+++ b/.pryrc
@@ -8,11 +8,8 @@ end
 
 # Add color coding based on Rails environment for safety
 if defined?(Rails) && defined?(Pry)
-  banner = if Rails.env.production?
-             "\e[41;97;1m #{Rails.env} \e[0m "
-           else
-             "\e[42;97;1m #{Rails.env} \e[0m "
-           end
+  banner_color = Rails.env.production? ? 41 : 42
+  banner = "\e[#{banner_color};97;1m #{Rails.env} \e[0m "
 
   Pry.config.prompt_name = banner
 end


### PR DESCRIPTION
By printing the env in the rails console we can avoid mistakes in production. Added the code both for `irb` and `pry`

<img width="370" alt="image" src="https://github.com/rootstrap/rails_api_base/assets/6373536/ffbe6ca3-307d-44c9-8d4e-df51b5d8d7ec">
<img width="344" alt="image" src="https://github.com/rootstrap/rails_api_base/assets/6373536/940535e0-26c6-4ff2-9c71-f09740fa7503">


https://twitter.com/_swanson/status/1346851840944730112/photo/1
https://gist.github.com/Intrepidd/af2bb4ed825817ecb044a5e93fc52f4d