### PR TITLE
Fix ActiveStorage::Current in request specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,8 +54,10 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-ActiveStorage::Current.url_options = { host: ENV.fetch('SERVER_HOST', nil),
-                                       port: ENV.fetch('PORT', 3000) }
+Rails.application.executor.to_complete do
+  ActiveStorage::Current.url_options = { host: ENV.fetch('SERVER_HOST', nil),
+                                         port: ENV.fetch('PORT', 3000) }
+end
 
 Flipper.configure do |config|
   config.default { Flipper.new(Flipper::Adapters::Memory.new) }


### PR DESCRIPTION
When running requests specs, Rails is automatically clearing all the `ActiveSupport::CurrentAttributes` including `ActiveStorage::Current`, so when doing `something.file.url` after the request, it failed with

```
     ArgumentError:
       Cannot generate URL for tree.fbx using Disk service, please set ActiveStorage::Current.url_options.
```

this is the place where Rails clears the attributes:
https://github.com/rails/rails/blob/main/activesupport/lib/active_support/railtie.rb#L49-L50

so with this change we are automatically setting the `ActiveStorage::Current.url_options` right after the request was performed.