### PR TITLE
Check and change some of our current rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,20 +29,10 @@ Layout/LineLength:
     - db/**/*
 
 Layout/SpaceBeforeFirstArg:
-  Exclude:
-    - app/views/api/**/**/*
+  AllowForAlignment: true
 
 Lint/AmbiguousBlockAssociation:
   AllowedMethods: change
-
-Lint/BinaryOperatorWithIdenticalOperands:
-  Enabled: false
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: false
-
-Lint/RaiseException:
-  Enabled: false
 
 Metrics/AbcSize:
   Max: 15
@@ -73,9 +63,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 12
 
-Rails/FilePath:
-  Enabled: false
-
 Rails/SaveBang:
   Enabled: true
 
@@ -88,11 +75,9 @@ RSpec/MultipleExpectations:
 RSpec/NamedSubject:
   Enabled: false
 
-Style/ArrayCoercion:
-  Enabled: true
-
 Style/BlockDelimiters:
-  EnforcedStyle: braces_for_chaining
+  Exclude:
+    - spec/**/*
 
 Style/Documentation:
   Enabled: false
@@ -103,35 +88,14 @@ Style/ExpandPathArguments:
 Style/GlobalStdStream:
   Enabled: false
 
-Style/HashEachMethods:
-  Enabled: false
-
 Style/HashLikeCase:
   MinBranchesCount: 4
-
-Style/HashTransformKeys:
-  Enabled: false
-
-Style/HashTransformValues:
-  Enabled: false
 
 Style/ModuleFunction:
   Enabled: false
 
-Style/RedundantFetchBlock:
-  Enabled: false
-
-Style/RedundantFileExtensionInRequire:
-  Enabled: false
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: false
-
 Style/ReturnNil:
   Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: false
 
 Style/StringConcatenation:
   Enabled: false

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,7 +6,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 
@@ -17,14 +17,14 @@ worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch('PORT') { 3000 }
+port ENV.fetch('PORT', 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch('RAILS_ENV') { 'development' }
+environment ENV.fetch('RAILS_ENV', 'development')
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
+pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together


### PR DESCRIPTION
#### Board:
[Notion ticket](https://www.notion.so/rootstrap/3950194b61e342628f6f56ce11200334?v=9f47a8bf83d34841819b3cf549859d94&p=c2884fc67f5f4f5089d1d80c230ae460&pm=s)

---
#### Description:
Checking the Rubocop rules we have set specific options to in our .rubocoop.yml

---
#### Notes:
List of changes or comments:

* Layout/SpaceBeforeFirstArg: Removed exception and added `AllowForAlignment` so it works ok for how we use it on views.
* Lint/BinaryOperatorWithIdenticalOperands: Removed, unlikely to be used but I only see positives as it removed redundancy.
* Lint/DeprecatedOpenSSLConstant: Removed, it’s a deprecation warning, we shouldn’t use deprecated stuff if possible.
* Lint/RaiseException: Removed, we shouldn’t raise plain Exceptions as catching them would mean catching every other kind of Exception in the same place.
* Style/ArrayCoercion: Removed as it can cause problems https://github.com/rubocop/rubocop/issues/8783.
* Rails/FilePath: Removed so it’s enabled, it’s good to always use the same syntax, the default is to use arguments but I’m fine if slashes are preferred.
* Style/BlockDelimiters: Removed except on specs, it feels wrong to use braces on multi line blocks, if this is how most of the company uses it nowadays then we can change it but I believe it’s the other way around. Left it on specs because it is usually how they are used for `expect { }.to` even if it's multiline..
* Style/ExpandPathArguments: I’m not really sure what difference this makes, never used it, might be good to have it turned on just to have consistency.
* Style/GlobalStdStream: Same as above.
* Style/HashEachMethods: Removed as it’s faster: https://stackoverflow.com/questions/46532459/what-is-the-difference-between-keys-each-and-each-key.
* Style/HashTransformKeys: Removed as we have the necessary version of ruby and it looks way less confusing.
* Style/HashTransformValues: Same as above.
* Style/RedundantFetchBlock: Removed as it's faster https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantFetchBlock.
* Style/RedundantFileExtensionInRequire: I’ve removed it since I’ve never seen us use require ‘something.rb’ explicitly.
* Style/RedundantRegexpCharacterClass: Removed it as it only looks positive.
* Style/ReturnNil: Do we usually return nil explicitly? Not used to this but not removing it as I’m not sure what most of us do.
* Style/SlicingWithRange: Removing it as we have the necessary ruby version.
* Style/StringConcatenation: I personally prefer interpolation, maybe using the conservative mode, wdpt? https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringConcatenation.


---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
* 
---
#### Preview:
