### PR TITLE
Knapsack ci workflow updates

### DIFF
--- a/.github/workflows/update_knapsack_report.yml
+++ b/.github/workflows/update_knapsack_report.yml
@@ -3,7 +3,7 @@ name: Update Knapsack Report
 # This workflow should be scheduled at certain intervals
 on:
   schedule:
-    - cron: '0 5 31 2 *'
+    - cron: '*/15 * * * *'
 # The above cron does not run. Replace with the wanted periodicity.
 # For example, the following configuration would schedule it every 3 months
 #    - cron: '0 0 1 */3 *'
@@ -50,7 +50,7 @@ jobs:
     - name: Push changes
       run: git push origin HEAD:update-knapsack-report
     - name: Initialize Pull Request
-      uses: rootstrap/create-pull-request@v3
+      uses: rootstrap/create-pull-request@v5
       with:
         pull_request_token: ${{ secrets.GITHUB_TOKEN }}
         head: update-knapsack-report

--- a/.github/workflows/update_knapsack_report.yml
+++ b/.github/workflows/update_knapsack_report.yml
@@ -29,7 +29,6 @@ jobs:
 
     env:
       RAILS_ENV: test
-      github_token: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/update_knapsack_report.yml
+++ b/.github/workflows/update_knapsack_report.yml
@@ -3,7 +3,7 @@ name: Update Knapsack Report
 # This workflow should be scheduled at certain intervals
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '0 5 31 2 *'
 # The above cron does not run. Replace with the wanted periodicity.
 # For example, the following configuration would schedule it every 3 months
 #    - cron: '0 0 1 */3 *'
@@ -52,8 +52,8 @@ jobs:
     - name: Initialize Pull Request
       uses: rootstrap/create-pull-request@v5
       with:
-        pull_request_token: ${{ secrets.GITHUB_TOKEN }}
-        head: update-knapsack-report
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: update-knapsack-report
         base: main
         title: 'Update Knapsack report'
         maintainer_can_modify: true

--- a/.github/workflows/update_knapsack_report.yml
+++ b/.github/workflows/update_knapsack_report.yml
@@ -1,12 +1,11 @@
 name: Update Knapsack Report
 
-# This workflow should be scheduled at certain intervals
 on:
-  schedule:
-    - cron: '0 5 31 2 *'
-# The above cron does not run. Replace with the wanted periodicity.
-# For example, the following configuration would schedule it every 3 months
+  workflow_dispatch:
+# This workflow should be scheduled at certain intervals
+# schedule:
 #    - cron: '0 0 1 */3 *'
+# The above cron would schedule it every 3 months. Replace with the wanted periodicity.
 
 jobs:
   build:

--- a/.github/workflows/update_knapsack_report.yml
+++ b/.github/workflows/update_knapsack_report.yml
@@ -3,7 +3,7 @@ name: Update Knapsack Report
 # This workflow should be scheduled at certain intervals
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/5 * * * *'
 # The above cron does not run. Replace with the wanted periodicity.
 # For example, the following configuration would schedule it every 3 months
 #    - cron: '0 0 1 */3 *'
@@ -29,14 +29,14 @@ jobs:
 
     env:
       RAILS_ENV: test
+      github_token: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 3.1
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        bundler-cache: true
     - name: Setup Database
       run: bundle exec rails db:create db:migrate
     - name: Update Knapsack Report

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -37,6 +37,10 @@ It is now scheduled for February 31 so will never run.
   - cron: '0 5 31 2 *'    
   # The above cron does not run. Replace with the wanted periodicity.
 ```
+ 
+If the branch exists or the PR is already created the workflow will fail.
+In your repository settings -> actions -> general ->  Workflow permissions we need to allow read / write permissions and mark the option allow Github action to create PR, other case the workflow will fail.
+
 ## Coverage
 When splitting tests in different nodes, each report covers only a part of the code files being tested.
 For this reason a job in the CI is added to sums coverages from all nodes to be used by SimpleCov. This job will be executed after all nodes have finished and will send the final report to CodeClimate.


### PR DESCRIPTION
#### Description:
Update Knapsack workflow

#### Notes:
If the branch exists or the PR is already created the workflow will fail.
In your repository settings -> actions -> general ->  Workflow permissions we need to allow read / write permissions and mark the option allow Github action to create Pr, other case the workflow will fail.

---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:
The PR looks like this
![image](https://github.com/rootstrap/rails_api_base/assets/22925144/a6c98560-7786-4445-8ecc-c0d6867a1321)

