### PR TITLE
Update docker env var during bootstrap

### DIFF
--- a/bin/helpers.rb
+++ b/bin/helpers.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'dotenv/load'
 
 def running_with_docker?
   ENV['DOCKER_ENABLED'] == 'true' && docker_compose_installed? && web_service_running?

--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require 'fileutils'
+require 'dotenv/load'
 require_relative 'bundler'
 
 # path to your application root.

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 require 'fileutils'
-require 'dotenv/load'
 require_relative 'bundler'
 
 # path to your application root.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -58,16 +58,24 @@ fi
 # generate a .env from the sample file
 cp .env.sample .env
 
-# update project name in database.yml
 # sed command implementation is different for GNU and macOS
-if [[ $OSTYPE == 'darwin'* ]]; then
-  sed -i '' "s/rails_api_base/${project_name}/g" config/database.yml
-else
-  sed -i "s/rails_api_base/${project_name}/g" config/database.yml
-fi
+sed_i() {
+  if [[ $OSTYPE == 'darwin'* ]]; then
+    sed -i '' $@
+  else
+    sed -i $@
+  fi
+}
+
+# update project name in database.yml
+sed_i "s/rails_api_base/${project_name}/g" config/database.yml
 
 # spin up docker services if flag is specified for the setup to take place inside the containers
 if [[ $docker -eq 1 ]]; then
+  # Update DOCKER_ENABLED variable in .env
+  sed_i "s/DOCKER_ENABLED=false/DOCKER_ENABLED=true/g" .env
+
+  # build and spin up containers
   docker-compose up --build --detach
 fi
 


### PR DESCRIPTION
#### Board:
* N/A
---
#### Description:

When using Docker, the setup script was failing / not working as expected. The `running_with_docker?` method checks the env var `DOCKER_ENABLED=true`, but the default is `false`. This adds a rewrite of that value if bootstrapping with Docker. I also added a utility method for the bootstrap script since this uses `sed` again, necessitating the OS check.

---
#### Notes:
* I'm new here, so I'm not sure if we want to load dotenv in all the bin scripts that reference `running_with_docker?`, but it seems like it might be worthwhile, if anyone runs those scripts in isolation.
---
#### Tasks:
N/A

---
#### Risk:
N/A

---
#### Preview:
N/A
