### PR TITLE
rspec retry - create an issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,17 @@ name: CI
 
 on: [push]
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
+
 env:
   RAILS_ENV: test
   CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+  CI: 'true'
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  REPO: ${{ github.repository }}
 
 jobs:
   linters:

--- a/Gemfile
+++ b/Gemfile
@@ -42,11 +42,13 @@ group :development, :test do
   gem 'dotenv-rails', '~> 2.8.1'
   gem 'factory_bot_rails', '~> 6.2'
   gem 'knapsack', '~> 4.0'
+  gem 'octokit', '~> 7.1'
   gem 'parallel_tests', '~> 4.3'
   gem 'pry-byebug', '~> 3.9', platform: :mri
   gem 'pry-rails', '~> 0.3.9'
   gem 'rspec_api_documentation', '~> 6.1.0'
   gem 'rspec-rails', '~> 6.0'
+  gem 'rspec-retry', github: 'rootstrap/rspec-retry', branch: 'add-intermittent-callback'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/rootstrap/rspec-retry.git
+  revision: 8266536fb6f4bc8d005c3863bcdfe8d7a6c9b203
+  branch: add-intermittent-callback
+  specs:
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -177,6 +185,11 @@ GEM
       railties (>= 5.0.0)
     faker (3.2.1)
       i18n (>= 1.8.11, < 2)
+    faraday (2.7.11)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     ffi (1.16.1)
     flipper (1.0.0)
       brow (~> 0.4.1)
@@ -287,6 +300,9 @@ GEM
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    octokit (7.2.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
     oj (3.16.1)
     orm_adapter (0.5.0)
     pagy (6.1.0)
@@ -453,6 +469,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
     sendgrid (1.2.4)
       json
     sexp_processor (4.16.1)
@@ -527,6 +546,7 @@ DEPENDENCIES
   listen (~> 3.8)
   lograge (~> 0.13)
   newrelic_rpm (~> 9.5)
+  octokit (~> 7.1)
   oj (~> 3.16)
   pagy (~> 6.1)
   parallel_tests (~> 4.3)
@@ -542,6 +562,7 @@ DEPENDENCIES
   rails_best_practices (~> 1.20)
   reek (~> 6.1, >= 6.1.1)
   rspec-rails (~> 6.0)
+  rspec-retry!
   rspec_api_documentation (~> 6.1.0)
   rubocop (~> 1.56)
   rubocop-factory_bot (~> 2.24)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -83,4 +83,13 @@ describe User do
       end
     end
   end
+
+  # Flaky test
+  describe 'flaky' do
+    $raise = [true, false]
+
+    it 'fails' do
+      raise if $raise.shift
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -83,13 +83,4 @@ describe User do
       end
     end
   end
-
-  # Flaky test
-  describe 'flaky' do
-    $raise = [true, false]
-
-    it 'fails' do
-      raise if $raise.shift
-    end
-  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,9 +20,14 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/core'
 require 'spec_helper'
 require 'rspec/rails'
+require 'rspec/retry'
+require 'support/retry/message_formatter'
 
 ActiveRecord::Migration.maintain_test_schema!
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: ['api.github.com']
+)
 
 RSpec.configure do |config|
   config.render_views = true
@@ -46,6 +51,19 @@ RSpec.configure do |config|
 
   # Reset previous flipper instance
   config.before { Flipper.instance = nil }
+
+  # rspec-retry gem
+  # Show retry status in spec process
+  config.verbose_retry = true
+  # Print what reason forced the retry
+  config.display_try_failure_messages = true
+  # Try tests twice in the CI and once locally
+  config.default_retry_count = ENV.fetch('CI', false) ? 2 : 1
+  # Callback for intermittent tests
+  config.intermittent_callback = proc do |ex|
+    text = Retry::MessageFormatter.new(ex).to_s
+    Retry::CreateIssue.new.create_issue('Issue name', text)
+  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,8 +61,8 @@ RSpec.configure do |config|
   config.default_retry_count = ENV.fetch('CI', false) ? 2 : 1
   # Callback for intermittent tests
   config.intermittent_callback = proc do |ex|
-    text = Retry::MessageFormatter.new(ex).to_s
-    Retry::CreateIssue.new.create_issue('Issue name', text)
+    message = Retry::MessageFormatter.new(ex)
+    Retry::CreateIssue.new.create_issue(message.title, message.to_s)
   end
 end
 

--- a/spec/support/retry/create_issue.rb
+++ b/spec/support/retry/create_issue.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Retry
+  class CreateIssue
+    attr_reader :repo, :client
+
+    def initialize
+      @repo = ENV.fetch('REPO', nil)
+      @github_token = ENV.fetch('GITHUB_TOKEN', nil)
+      @client = Octokit::Client.new(access_token: @github_token)
+    end
+
+    def create_issue(title, body)
+      issue = client.create_issue(repo, title, body)
+      pp "Issue created: #{issue.html_url}"
+    rescue StandardError => e
+      p e.message
+    end
+  end
+end

--- a/spec/support/retry/create_issue.rb
+++ b/spec/support/retry/create_issue.rb
@@ -13,8 +13,8 @@ module Retry
     def create_issue(title, body)
       issue = client.create_issue(repo, title, body)
       pp "Issue created: #{issue.html_url}"
-    rescue StandardError => e
-      p e.message
+    rescue StandardError => error
+      p error.message
     end
   end
 end

--- a/spec/support/retry/message_formatter.rb
+++ b/spec/support/retry/message_formatter.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Retry
+  class MessageFormatter
+    attr_reader :example
+
+    def initialize(example)
+      @example = example
+    end
+
+    def to_s
+      "\n*Failed test:*" \
+        "\n> Scenario: _#{description}_" \
+        "\n> File: #{error_location}" \
+        "\n> Seed: #{RSpec.configuration.seed}" \
+        "\n> Error: ```#{error}```\n"
+    end
+
+    private
+
+    def description
+      example.metadata[:full_description]
+    end
+
+    def error
+      example.execution_result.exception.to_s.split("\nDiff").first.presence ||
+        example.metadata[:retry_exceptions].first
+    end
+
+    def error_location
+      example.metadata[:location]
+    end
+  end
+end

--- a/spec/support/retry/message_formatter.rb
+++ b/spec/support/retry/message_formatter.rb
@@ -16,6 +16,10 @@ module Retry
         "\n> Error: ```#{error}```\n"
     end
 
+    def title
+      "Flaky test on #{error_location}"
+    end
+
     private
 
     def description


### PR DESCRIPTION
#### Board:
* [Ticket #NUMBER_OF_THE_TICKET](link_goes_here)
---
#### Description:
In this PR, we add the 'rspec-retry' gem and configure it to retry tests twice. 
In case of a failure on the first attempt, and a subsequent pass on the second, an issue will be created with information about the problematic test. (If the test fails always the issue won’t be created.
The issue looks like [this](https://github.com/rootstrap/rails_api_base/issues/491)

#### Notes:
*
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:
