### PR TITLE
Enable daily version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,5 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
#### Board:
* N/A
---
#### Description:
- I noticed that Dependabot tried to open new pull requests to update gem versions but the current limit is 5 weekly PRs.
- This PR aim is to increase that limit to up to 10 PRs every day.
---
#### Notes:
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval
---
#### Preview:
![Captura de pantalla 2023-10-19 a la(s) 13 07 06](https://github.com/rootstrap/rails_api_base/assets/27789496/f5aafeab-3e53-4f8f-a7d6-5c959560849f)
