### PR TITLE
Hotfix Ransack 4.0.0

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -10,7 +10,9 @@ detectors:
     exclude: []
   ControlParameter:
     enabled: true
-    exclude: []
+    exclude:
+      - 'Ransackable#ransackable_associations'
+      - 'Ransackable#ransackable_attributes'
   DataClump:
     enabled: true
     exclude: []

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -29,4 +29,7 @@ class AdminUser < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  RANSACK_ATTRIBUTES = %w[id email sign_in_count current_sign_in_at last_sign_in_at
+                          current_sign_in_ip last_sign_in_ip created_at updated_at].freeze
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,6 +2,7 @@
 
 class ApplicationRecord < ActiveRecord::Base
   include ActiveStorageSupport::SupportForBase64
+  include Ransackable
 
   self.abstract_class = true
 end

--- a/app/models/concerns/ransackable.rb
+++ b/app/models/concerns/ransackable.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Ransackable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def ransackable_attributes(auth_object = nil)
+      return (column_names + ransackers.keys) if auth_object == :admin
+
+      const_defined?(:RANSACK_ATTRIBUTES) ? self::RANSACK_ATTRIBUTES : []
+    end
+
+    def ransackable_associations(auth_object = nil)
+      return reflect_on_all_associations.map { |association| association.name.to_s } if auth_object == :admin
+
+      const_defined?(:RANSACK_ASSOCIATIONS) ? self::RANSACK_ASSOCIATIONS : []
+    end
+  end
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -17,4 +17,6 @@
 
 class Setting < ApplicationRecord
   validates :key, uniqueness: true, presence: true
+
+  RANSACK_ATTRIBUTES = %w[id key value].freeze
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,10 @@ class User < ApplicationRecord
 
   before_validation :init_uid
 
+  RANSACK_ATTRIBUTES = %w[id email first_name last_name username sign_in_count current_sign_in_at
+                          last_sign_in_at current_sign_in_ip last_sign_in_ip provider uid
+                          created_at updated_at].freeze
+
   def self.from_social_provider(provider, user_params)
     where(provider:, uid: user_params['id']).first_or_create! do |user|
       user.password = Devise.friendly_token[0, 20]


### PR DESCRIPTION
#### Board:
* [Ticket #NUMBER_OF_THE_TICKET](link_goes_here)
---
#### Description:
This [PR](https://github.com/rootstrap/rails_api_base/pull/483) introduced new version of Ransack gem (4.0.0). This introduced some breaking changes and prevents the use of current ActiveAdmin sections.

This [article](https://rogodev.com/ransack-40-allowlist-changes) explains the reason and how to fix the issue.

Let me know if this is the best possible solution. 😄

#### Risk:
* High
---
#### Preview:
![Captura de pantalla 2023-10-19 a la(s) 13 52 34](https://github.com/rootstrap/rails_api_base/assets/27789496/f6502b51-b6f4-491d-8bf6-b378ad477c3e)
