### PR TITLE
Fix obscure bug

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -7,19 +7,14 @@ module Api
       include Pundit::Authorization
       include DeviseTokenAuth::Concerns::SetUserByToken
 
+      before_action :authenticate_user!
+
       after_action :verify_authorized, except: :index
       after_action :verify_policy_scoped, only: :index
-
-      before_action :authenticate_user!, except: :status
-      skip_after_action :verify_authorized, only: :status
 
       rescue_from ActiveRecord::RecordNotFound,        with: :render_not_found
       rescue_from ActiveRecord::RecordInvalid,         with: :render_record_invalid
       rescue_from ActionController::ParameterMissing,  with: :render_parameter_missing
-
-      def status
-        render json: { online: true }
-      end
 
       private
 

--- a/app/controllers/api/v1/health_controller.rb
+++ b/app/controllers/api/v1/health_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class HealthController < Api::V1::ApiController
+      skip_before_action :authenticate_user!
+      skip_after_action :verify_authorized
+
+      def status
+        render json: { online: true }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1, defaults: { format: :json } do
-      get :status, to: 'api#status'
+      get :status, to: 'health#status'
 
       devise_scope :user do
         resource :user, only: %i[update show]


### PR DESCRIPTION
Having the `status` action defined in `ApiController` which is then inherited by other controllers, was causing a very strange bug related to the [wrap_parameters](https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html) Rails feature.

In order to reproduce go to the `main` branch, perform the following changes to force the execution of the wrap_parameters feature:
```diff
+++ spec/requests/api/v1/users/update_spec.rb
@@ -9,14 +9,14 @@ describe 'PUT api/v1/user/' do
   before { subject }

   context 'with valid params' do
-    let(:params) { { user: { username: 'new username' } } }
+    let(:params) { { username: 'new username' } }

     it 'returns success' do
       expect(response).to have_http_status(:success)
     end

     it 'updates the user' do
-      expect(user.reload.username).to eq(params[:user][:username])
+      expect(user.reload.username).to eq(params[:username])
     end
```
and run:
```bash
bundle exec rspec spec/requests/api/v1/status_spec.rb spec/requests/api/v1/users/update_spec.rb --order defined
```

as you can see it fails. The reason is that Rails is wrapping the parameters for the projects/update endpoint in a key named "api" instead of the correct one "user"