### PR TITLE
Make api base ready for fullstack

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -9,5 +9,5 @@
  * compiled file, but it's generally better to create a new file per style scope.
  *
  *= require_self
- *= require_tree .
+ *= require_tree ./application
  */

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>rails_api_base</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag "application" %>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,17 +58,6 @@ module App
       g.fixture_replacement :factory_bot, dir: 'spec/factories'
     end
 
-    # Only loads a smaller set of middleware suitable for API only apps.
-    # Middleware like session, flash, cookies can be added back manually.
-    # Skip views, helpers and assets when generating a new resource.
-    config.api_only = true
-
-    # ActiveAdmin needs the following middlewares to work properly.
-    config.middleware.use ActionDispatch::Cookies
-    config.middleware.use ActionDispatch::Session::CookieStore
-    config.middleware.use ActionDispatch::Flash
-    config.middleware.use Rack::MethodOverride
-
     # Log N+1s using Rails strict_loading feature
     ENV['DISABLE_RAILS_STRICT_LOADING'] ||= 'true' if defined?(Rails::Console)
     config.active_record.strict_loading_by_default = ENV['DISABLE_RAILS_STRICT_LOADING'] != 'true'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,6 +85,4 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
-
-  config.debug_exception_response_format = :default
 end


### PR DESCRIPTION
### 1. Remove `api_only` config
Revert https://github.com/rootstrap/rails_api_base/pull/253/files. We aren't getting any benefit from it.
Actually, our app is not api only, we still are loading middlewares because they are needed for ActiveAdmin.

### 2. Add default application layout
Every Rails app comes with one https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
It will be helpful if we ever want to develop an HTML page outside the admin site.

### 3. Keep application and admin CSS separate
We don't want Arctic Admin styles to leak into application CSS, for that reason, application CSS should go into the `app/assets/stylesheets/application/` directory