### PR TITLE
Don't check CSRF for API requests

### DIFF
--- a/app/controllers/api/concerns/act_as_api_request.rb
+++ b/app/controllers/api/concerns/act_as_api_request.rb
@@ -8,6 +8,7 @@ module Api
       included do
         before_action :skip_session_storage
         before_action :check_json_request
+        protect_from_forgery with: :null_session
       end
 
       def check_json_request


### PR DESCRIPTION
https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html

>APIs may want to disable this behavior since they are typically designed to be state-less: that is, the request API client handles the session instead of Rails. One way to achieve this is to use the :null_session strategy instead, which allows unverified requests to be handled, but with an empty session: