### PR TITLE
Fix deprecation warnings for Swagger

### DIFF
--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -5,7 +5,7 @@ Rswag::Api.configure do |c|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.swagger_root = "#{Rails.root}/doc"
+  c.openapi_root = "#{Rails.root}/doc"
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -9,7 +9,7 @@ Rswag::Ui.configure do |c|
   # (under swagger_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.swagger_endpoint '/api-docs/openapi.yaml', 'API V1 Docs'
+  c.openapi_endpoint '/api-docs/openapi.yaml', 'API V1 Docs'
 
   # Add Basic Auth in case your API is private
   c.basic_auth_enabled = true


### PR DESCRIPTION
#### Board:
* [Ticket Resolve DEPRECATION WARNING related with swagger gems](https://www.notion.so/rootstrap/Resolve-DEPRECATION-WARNING-related-with-swagger-gems-2c1a20f30a8c4ee789e6b0a099c895ac?pvs=25)
---
#### Description:
* Replace deprecated methods for rswag gems
---
#### Notes:
```shell
17:10:57 web.1  | DEPRECATION WARNING: swagger_root= is deprecated and will be removed from rswag-api 3.0 (use openapi_root= instead) (called from block in <main> at /Users/samirtapiero/Backend/rails_api_base/config/initializers/rswag_api.rb:8)
17:10:57 web.1  | DEPRECATION WARNING: Rswag::Ui: WARNING: The method will be renamed to "openapi_endpoint" in v3.0 (called from block in <main> at /Users/samirtapiero/Backend/rails_api_base/config/initializers/rswag_ui.rb:12)
```
---
#### Preview:

![image](https://github.com/rootstrap/rails_api_base/assets/50454914/d4c64d85-77f1-4396-9ddc-116d59164ad9)

