### PR TITLE
Also keep GHA actions and JS packages up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "yarn"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Also make dependabot keep GHA actions (e.g. actions/checkout) up to date, and JS packages (package.json and yarn.lock) up to date