### PR TITLE
Fix dependabot package-ecosystem for yarn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
I made a mistake and it should have been `npm` not `yarn in the `dependabot.yml`

<img width="1280" alt="image" src="https://github.com/rootstrap/rails_api_base/assets/6373536/2f5cd931-74bf-4e82-b860-6fcb20ab28d4">


<img width="764" alt="image" src="https://github.com/rootstrap/rails_api_base/assets/6373536/296e4faf-5f8c-4f86-a360-1026bc248523">
