### PR TITLE
Ensuring consistency of API routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: '/api/v1/users', controllers: {
-    registrations: 'api/v1/registrations',
-    sessions: 'api/v1/sessions',
-    passwords: 'api/v1/passwords'
-  }
+  scope format: 'json' do
+    mount_devise_token_auth_for 'User', at: '/api/v1/users', controllers: {
+      registrations: 'api/v1/registrations',
+      sessions: 'api/v1/sessions',
+      passwords: 'api/v1/passwords'
+    }
+  end
 
   namespace :api do
     namespace :v1, defaults: { format: :json } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  scope format: 'json' do
+  scope format: :json do
     mount_devise_token_auth_for 'User', at: '/api/v1/users', controllers: {
       registrations: 'api/v1/registrations',
       sessions: 'api/v1/sessions',


### PR DESCRIPTION
Small fix on routes file.
Need to force JSON scope to prevent Devise routes from defaulting the request format to `*/*`
