### PR TITLE
Fix DeviseTokenAuth gem UnsafeRedirectError

### DIFF
--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -10,9 +10,7 @@ module API
       private
 
       def redirect_options
-        {
-          allow_other_host: true
-        }
+        { allow_other_host: true }
       end
     end
   end

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -6,6 +6,14 @@ module API
       protect_from_forgery with: :exception, unless: :json_request?
       include API::Concerns::ActAsAPIRequest
       skip_before_action :check_json_request, on: :edit
+
+      private
+
+      def redirect_options
+        {
+          allow_other_host: true
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
Related to https://github.com/lynndylanhurley/devise_token_auth/issues/1536

When running the tests, I get some errors like this one:
```
# With Docker
$ DOCKER_ENABLED=true ./bin/rspec

# Without Docker
$ ./bin/rspec

1) PUT api/v1/users/passwords/ with valid params returns a successful response
     Failure/Error: get edit_user_password_path, params:, headers: auth_headers

     ActionController::Redirecting::UnsafeRedirectError:
       Unsafe redirect to "http://127.0.0.1:3000?access-token=2LGXSO3yWsPxPWCyGml-wA&client=MJDpDQiAegGCGFWy3qDS_A&client_id...", pass allow_other_host: true to redirect anyway.
     # ./spec/requests/api/v1/passwords/update_spec.rb:11:in `block (2 levels) in <top (required)>'
     # ./spec/requests/api/v1/passwords/update_spec.rb:29:in `block (3 levels) in <top (required)>'
```

Rails 7 raises `ActionController::Redirecting::UnsafeRedirectError` for unsafe `redirect_to` redirects. https://github.com/rails/rails/commit/c3758a71af949db849d5b7f176677653e4e4fae9

Adding the `allow_other_host` option for the `DeviseTokenAuth` controllers fixes the issue.

Should we make this change only for the test env? Thoughts?