### PR TITLE
Skip OPENAPI in hooks_spec

### DIFF
--- a/spec/requests/api/v1/concerns/impersonation/hooks_spec.rb
+++ b/spec/requests/api/v1/concerns/impersonation/hooks_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'API::Concerns::Impersonation::Hooks' do
+RSpec.describe 'API::Concerns::Impersonation::Hooks', openapi: false do
   before do
     stub_const('FakeController', Class.new(API::V1::APIController) do
       include API::Concerns::Impersonation::Hooks


### PR DESCRIPTION
#### Board:
Skip OPENAPI in hooks spec.
---
#### Description:

The hooks spec mocks an endpoint, causing OPENAPI to fail. Since we don't require API documentation for a mocked endpoint, this PR skips OPENAPI docs generation in hooks_spec