### PR TITLE
Add impersonated header to rack_cors

### DIFF
--- a/app/objects/impersonation/headers.rb
+++ b/app/objects/impersonation/headers.rb
@@ -7,7 +7,7 @@ module Impersonation
     end
 
     def build_impersonation_header
-      { 'impersonated' => @user.impersonated_by.present? }.compact_blank
+      { 'impersonated' => @user&.impersonated_by.present? }.compact_blank
     end
   end
 end

--- a/config/initializers/rack_cors.rb
+++ b/config/initializers/rack_cors.rb
@@ -8,7 +8,7 @@ module App
         resource '*',
                  headers: :any,
                  methods: %i[get post options put delete],
-                 expose: %w[access-token uid client]
+                 expose: %w[access-token uid client impersonated]
       end
     end
   end


### PR DESCRIPTION
#### Description:

- Add the impersonated header to rack_cors. We need this header to be exposed in the headers response to allow for impersonation.
- Fix a small issue in the `build_impersonation_header` method. The @user does not exist when we make the first request to `POST /impersonations`
