### PR TITLE
Exclude status endpoint to prevent redirect in healthcheck verify

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,6 +54,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?('api/v1/status') } } }
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
#### Board:
* [Ticket #NUMBER_OF_THE_TICKET](link_goes_here)
---
#### Description:
Add `ssl_options` to exclude the status endpoint from ssl redirect and prevent issues with health-check verification 

based on https://api.rubyonrails.org/classes/ActionDispatch/SSL.html

#### Notes:
* Currently we have problem with the Load Balancer when we have the `force_ssl` enabled, with this setup we can omit the ssl redirect in the status endpoint
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:
