### PR TITLE
Add missing change in the `schema.rb` and re-order steps in the "How to use" section of the `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ This template comes with:
 1. Install PostgreSQL in case you don't have it
 1. Install node and yarn.
 1. Run `bootstrap.sh` with the name of your project like `./bin/bootstrap.sh --name=my_awesome_project`
-1. `bundle exec rspec` and make sure all tests pass (non-headless mode) or `HEADLESS=true bundle exec rspec` (headless mode)
 1. Run `yarn install` and `yarn build --watch`. This bundles the JS assets in the administration site using [esbuild](https://github.com/evanw/esbuild).
+1. `bundle exec rspec` and make sure all tests pass (non-headless mode) or `HEADLESS=true bundle exec rspec` (headless mode)
 1. Run `bin/dev`.
 1. You can now try your REST services!
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_09_165800) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_09_165800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
#### Description:
* The `schema.rb` version is not updated with our current `rails version`
* If you run `bundle exec rspec` before running `yarn install`, you get two failing tests

#### Preview:

![Screenshot 2024-04-05 at 5 17 36 PM](https://github.com/rootstrap/rails_api_base/assets/33032571/57760477-470e-4720-a677-1607ecc1804c)

