### PR TITLE
Misc improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ require:
   - rubocop-rails
   - rubocop-rake
   - rubocop-rspec
+  - rubocop-rspec_rails
 
 AllCops:
   NewCops: enable

--- a/app/controllers/api/concerns/act_as_api_request.rb
+++ b/app/controllers/api/concerns/act_as_api_request.rb
@@ -22,18 +22,10 @@ module API
         request.session_options[:skip] = true
       end
 
-      def render_error(status, message, _data = nil)
-        render json: { error: message }, status:
-      end
-
       private
 
       def request_with_body?
         request.post? || request.put? || request.patch?
-      end
-
-      def json_request?
-        request.format.json?
       end
     end
   end

--- a/app/controllers/api/concerns/act_as_api_request.rb
+++ b/app/controllers/api/concerns/act_as_api_request.rb
@@ -11,7 +11,7 @@ module API
       end
 
       def check_json_request
-        return if !request_with_body? || request_content_type.include?('json')
+        return if !request_with_body? || request.content_type&.include?('json')
 
         render json: { error: I18n.t('api.errors.invalid_content_type') }, status: :not_acceptable
       end
@@ -23,17 +23,10 @@ module API
       end
 
       def render_error(status, message, _data = nil)
-        response = {
-          error: message
-        }
-        render json: response, status:
+        render json: { error: message }, status:
       end
 
       private
-
-      def request_content_type
-        request.content_type || ''
-      end
 
       def request_with_body?
         request.post? || request.put? || request.patch?

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -19,18 +19,20 @@ module API
       private
 
       def render_not_found(exception)
-        logger.info { exception } # for logging
-        render json: { error: I18n.t('api.errors.not_found') }, status: :not_found
+        render_error(exception, { message: I18n.t('api.errors.not_found') }, :not_found)
       end
 
       def render_record_invalid(exception)
-        logger.info { exception } # for logging
-        render json: { errors: exception.record.errors.as_json }, status: :bad_request
+        render_error(exception, exception.record.errors.as_json, :bad_request)
       end
 
       def render_parameter_missing(exception)
-        logger.info { exception } # for logging
-        render json: { error: I18n.t('api.errors.missing_param') }, status: :unprocessable_entity
+        render_error(exception, { message: I18n.t('api.errors.missing_param') }, :unprocessable_entity)
+      end
+
+      def render_error(exception, errors, status)
+        logger.info { exception }
+        render json: { errors: Array.wrap(errors) }, status:
       end
     end
   end

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -5,7 +5,6 @@ module API
     class PasswordsController < DeviseTokenAuth::PasswordsController
       include API::Concerns::ActAsAPIRequest
       skip_forgery_protection
-      skip_before_action :check_json_request, on: :edit
 
       private
 

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -3,14 +3,18 @@
 module API
   module V1
     class PasswordsController < DeviseTokenAuth::PasswordsController
-      protect_from_forgery with: :exception, unless: :json_request?
       include API::Concerns::ActAsAPIRequest
+      skip_forgery_protection
       skip_before_action :check_json_request, on: :edit
 
       private
 
       def redirect_options
         { allow_other_host: true }
+      end
+
+      def render_error(status, message, _data = nil)
+        render json: { errors: Array.wrap(message:) }, status:
       end
     end
   end

--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -4,7 +4,7 @@ module API
   module V1
     class PasswordsController < DeviseTokenAuth::PasswordsController
       include API::Concerns::ActAsAPIRequest
-      skip_forgery_protection
+      protect_from_forgery with: :null_session
 
       private
 

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -4,7 +4,7 @@ module API
   module V1
     class RegistrationsController < DeviseTokenAuth::RegistrationsController
       include API::Concerns::ActAsAPIRequest
-      skip_forgery_protection
+      protect_from_forgery with: :null_session
 
       private
 

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -3,8 +3,8 @@
 module API
   module V1
     class RegistrationsController < DeviseTokenAuth::RegistrationsController
-      protect_from_forgery with: :exception, unless: :json_request?
       include API::Concerns::ActAsAPIRequest
+      skip_forgery_protection
 
       private
 
@@ -15,6 +15,10 @@ module API
 
       def render_create_success
         render :create
+      end
+
+      def render_error(status, message, _data = nil)
+        render json: { errors: Array.wrap(message:) }, status:
       end
     end
   end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -4,7 +4,7 @@ module API
   module V1
     class SessionsController < DeviseTokenAuth::SessionsController
       include API::Concerns::ActAsAPIRequest
-      skip_forgery_protection
+      protect_from_forgery with: :null_session
 
       private
 

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -3,8 +3,8 @@
 module API
   module V1
     class SessionsController < DeviseTokenAuth::SessionsController
-      protect_from_forgery with: :null_session
       include API::Concerns::ActAsAPIRequest
+      skip_forgery_protection
 
       private
 
@@ -14,6 +14,10 @@ module API
 
       def render_create_success
         render :create
+      end
+
+      def render_error(status, message, _data = nil)
+        render json: { errors: Array.wrap(message:) }, status:
       end
     end
   end

--- a/spec/requests/api/v1/concerns/impersonation/hooks_spec.rb
+++ b/spec/requests/api/v1/concerns/impersonation/hooks_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'API::Concerns::Impersonation::Hooks', openapi: false do
 
   describe '#show' do
     subject do
-      get '/show', headers: auth_headers, as: :json
+      get '/show', headers: auth_headers
     end
 
     let(:user) { create(:user) }

--- a/spec/requests/api/v1/registrations/create_spec.rb
+++ b/spec/requests/api/v1/registrations/create_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe 'POST api/v1/users/sign_up' do
+  subject { post user_registration_path, params:, as: :json }
+
+  let(:email) { 'email@example.com' }
+  let(:password) { 'password' }
+  let(:password_confirmation) { 'password' }
+  let(:username) { 'username' }
+  let(:first_name) { 'first name' }
+  let(:last_name) { 'last name' }
+  let(:params) do
+    {
+      user: {
+        email:,
+        password:,
+        password_confirmation:,
+        username:,
+        first_name:,
+        last_name:
+      }
+    }
+  end
+
+  context 'with correct params' do
+    before do
+      subject
+    end
+
+    it_behaves_like 'there must not be a Set-Cookie in Header'
+    it_behaves_like 'does not check authenticity token'
+
+    it 'returns success' do
+      expect(response).to be_successful
+    end
+
+    it 'returns the user' do
+      user = User.last
+      expect(json[:user][:id]).to eq(user.id)
+      expect(json[:user][:email]).to eq(user.email)
+      expect(json[:user][:username]).to eq(user.username)
+      expect(json[:user][:uid]).to eq(user.uid)
+      expect(json[:user][:provider]).to eq('email')
+      expect(json[:user][:first_name]).to eq(user.first_name)
+      expect(json[:user][:last_name]).to eq(user.last_name)
+    end
+
+    it 'returns a valid client and access token' do
+      user = User.last
+      token = response.header['access-token']
+      client = response.header['client']
+      expect(user.reload).to be_valid_token(token, client)
+    end
+  end
+
+  context 'with incorrect params' do
+    let(:params) do
+      {
+        user: {
+          email:,
+          password:,
+          password_confirmation: 'wrong_password!'
+        }
+      }
+    end
+
+    it 'returns to be a client error' do
+      subject
+      expect(response).to be_client_error
+    end
+
+    it 'return errors upon failure' do
+      subject
+      expect(json.to_s).to match("Password confirmation doesn't match Password") 
+    end
+  end
+end

--- a/spec/requests/api/v1/registrations/create_spec.rb
+++ b/spec/requests/api/v1/registrations/create_spec.rb
@@ -3,21 +3,15 @@
 describe 'POST api/v1/users/sign_up' do
   subject { post user_registration_path, params:, as: :json }
 
-  let(:email) { 'email@example.com' }
-  let(:password) { 'password' }
-  let(:password_confirmation) { 'password' }
-  let(:username) { 'username' }
-  let(:first_name) { 'first name' }
-  let(:last_name) { 'last name' }
   let(:params) do
     {
       user: {
-        email:,
-        password:,
-        password_confirmation:,
-        username:,
-        first_name:,
-        last_name:
+        email: 'email@example.com',
+        password: 'password',
+        password_confirmation: 'password',
+        username: 'username',
+        first_name: 'first name',
+        last_name: 'last name'
       }
     }
   end
@@ -37,12 +31,12 @@ describe 'POST api/v1/users/sign_up' do
     it 'returns the user' do
       user = User.last
       expect(json[:user][:id]).to eq(user.id)
-      expect(json[:user][:email]).to eq(user.email)
-      expect(json[:user][:username]).to eq(user.username)
+      expect(json[:user][:email]).to eq(params.dig(:user, :email))
+      expect(json[:user][:username]).to eq(params.dig(:user, :username))
       expect(json[:user][:uid]).to eq(user.uid)
       expect(json[:user][:provider]).to eq('email')
-      expect(json[:user][:first_name]).to eq(user.first_name)
-      expect(json[:user][:last_name]).to eq(user.last_name)
+      expect(json[:user][:first_name]).to eq(params.dig(:user, :first_name))
+      expect(json[:user][:last_name]).to eq(params.dig(:user, :last_name))
     end
 
     it 'returns a valid client and access token' do
@@ -57,8 +51,8 @@ describe 'POST api/v1/users/sign_up' do
     let(:params) do
       {
         user: {
-          email:,
-          password:,
+          email: 'email@example.com',
+          password: 'password',
           password_confirmation: 'wrong_password!'
         }
       }
@@ -71,7 +65,7 @@ describe 'POST api/v1/users/sign_up' do
 
     it 'return errors upon failure' do
       subject
-      expect(json.to_s).to match("Password confirmation doesn't match Password") 
+      expect(json.to_s).to match("Password confirmation doesn't match Password")
     end
   end
 end

--- a/spec/requests/api/v1/sessions/create_spec.rb
+++ b/spec/requests/api/v1/sessions/create_spec.rb
@@ -62,7 +62,7 @@ describe 'POST api/v1/users/sign_in' do
     it 'return errors upon failure' do
       subject
       expected_response = {
-        error: 'Invalid login credentials. Please try again.'
+        errors: [{ message: 'Invalid login credentials. Please try again.' }]
       }.with_indifferent_access
       expect(json).to eq(expected_response)
     end

--- a/spec/requests/api/v1/status_spec.rb
+++ b/spec/requests/api/v1/status_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'GET api/v1/status' do
   before do
-    get api_v1_status_path, as: :json
+    get api_v1_status_path
   end
 
   it 'returns status 200 ok' do

--- a/spec/requests/api/v1/users/show_spec.rb
+++ b/spec/requests/api/v1/users/show_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'GET api/v1/users/:id' do
-  subject { get api_v1_user_path, headers: auth_headers, as: :json }
+  subject { get api_v1_user_path, headers: auth_headers }
 
   let(:user) { create(:user) }
 

--- a/spec/requests/api/v1/users/update_spec.rb
+++ b/spec/requests/api/v1/users/update_spec.rb
@@ -40,7 +40,7 @@ describe 'PUT api/v1/user/' do
     end
 
     it 'returns the error' do
-      expect(json[:errors][:email]).to include('is not an email')
+      expect(json.dig(:errors, 0, :email)).to include('is not an email')
     end
   end
 
@@ -48,7 +48,7 @@ describe 'PUT api/v1/user/' do
     let(:params) { {} }
 
     it 'returns the missing params error' do
-      expect(json[:error]).to eq 'A required param is missing'
+      expect(json.dig(:errors, 0, :message)).to eq 'A required param is missing'
     end
   end
 end

--- a/spec/support/retry/message_formatter.rb
+++ b/spec/support/retry/message_formatter.rb
@@ -9,7 +9,7 @@ module Retry
     end
 
     def to_s
-      "\n*Failed test:*" \
+      "\n*Intermittent test found:*" \
         "\n> Scenario: _#{description}_" \
         "\n> File: #{error_location}" \
         "\n> Seed: #{RSpec.configuration.seed}" \

--- a/spec/support/shared_examples/requests/forgery_protection_disabled.rb
+++ b/spec/support/shared_examples/requests/forgery_protection_disabled.rb
@@ -2,16 +2,15 @@
 
 RSpec.shared_examples 'does not check authenticity token' do
   context 'with forgery protection enabled' do
-    before do
+    around do |example|
       ActionController::Base.allow_forgery_protection = true
-    end
-
-    after do
+      example.run
       ActionController::Base.allow_forgery_protection = false
     end
 
-    it 'does not raise an error' do
-      expect { subject }.not_to raise_error
+    it 'does not fail' do
+      subject
+      expect(response).not_to be_client_error
     end
   end
 end


### PR DESCRIPTION
Many minor improvements:
1. Add `rubocop-rspec_rails` to `.rubocop.yml` because it was not being loaded
2. Don't use `as: :json` for GET requests in the specs because they get converted to POST
3. Simplify `ActAsAPIRequest` concern
4. Unify response format when rendering errors with `render_error`
5. Add specs for sign up
6. Improve message when reporting an intermittent test
7. Fix forgery protection tests
