### PR TITLE
Annotate gem disables Rubocop Layout/LineLength for its comments

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,28 +1,38 @@
 # frozen_string_literal: true
 
+# rubocop:disable Layout/LineLength
 # == Schema Information
 #
 # Table name: admin_users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string           default(""), not null
+#  id                     :bigint           not null, primary key
+#  provider               :string           default("email"), not null
+#  uid                    :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
+#  allow_password_change  :boolean          default(FALSE)
 #  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  confirmation_sent_at   :datetime
+#  unconfirmed_email      :string
+#  name                   :string
+#  nickname               :string
+#  image                  :string
+#  email                  :string
+#  tokens                 :json
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
 # Indexes
 #
+#  index_admin_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_admin_users_on_email                 (email) UNIQUE
 #  index_admin_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_admin_users_on_uid_and_provider      (uid,provider) UNIQUE
 #
+# rubocop:enable Layout/LineLength
 
 class AdminUser < ApplicationRecord
   # Include default devise modules. Others available are:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,35 +1,38 @@
 # frozen_string_literal: true
 
+# rubocop:disable Layout/LineLength
 # == Schema Information
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string
+#  id                     :bigint           not null, primary key
+#  provider               :string           default("email"), not null
+#  uid                    :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
-#  allow_password_change  :boolean          default(FALSE), not null
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
-#  first_name             :string           default("")
-#  last_name              :string           default("")
-#  username               :string           default("")
+#  allow_password_change  :boolean          default(FALSE)
+#  remember_created_at    :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  confirmation_sent_at   :datetime
+#  unconfirmed_email      :string
+#  name                   :string
+#  nickname               :string
+#  image                  :string
+#  email                  :string
+#  tokens                 :json
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  provider               :string           default("email"), not null
-#  uid                    :string           default(""), not null
-#  tokens                 :json
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_users_on_uid_and_provider      (uid,provider) UNIQUE
 #
+# rubocop:enable Layout/LineLength
 
 class User < ApplicationRecord
   # Include default devise modules. Others available are:

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -30,7 +30,9 @@ if Rails.env.local?
       'format_markdown' => 'false',
       'sort' => 'false',
       'force' => 'false',
-      'trace' => 'false'
+      'trace' => 'false',
+      'wrapper_open' => 'rubocop:disable Layout/LineLength',
+      'wrapper_close' => 'rubocop:enable Layout/LineLength'
     )
   end
 

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -1,28 +1,38 @@
 # frozen_string_literal: true
 
+# rubocop:disable Layout/LineLength
 # == Schema Information
 #
 # Table name: admin_users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string           default(""), not null
+#  id                     :bigint           not null, primary key
+#  provider               :string           default("email"), not null
+#  uid                    :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
+#  allow_password_change  :boolean          default(FALSE)
 #  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  confirmation_sent_at   :datetime
+#  unconfirmed_email      :string
+#  name                   :string
+#  nickname               :string
+#  image                  :string
+#  email                  :string
+#  tokens                 :json
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
 # Indexes
 #
+#  index_admin_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_admin_users_on_email                 (email) UNIQUE
 #  index_admin_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_admin_users_on_uid_and_provider      (uid,provider) UNIQUE
 #
+# rubocop:enable Layout/LineLength
 
 FactoryBot.define do
   factory :admin_user do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,35 +1,38 @@
 # frozen_string_literal: true
 
+# rubocop:disable Layout/LineLength
 # == Schema Information
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string
+#  id                     :bigint           not null, primary key
+#  provider               :string           default("email"), not null
+#  uid                    :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
-#  allow_password_change  :boolean          default(FALSE), not null
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
-#  first_name             :string           default("")
-#  last_name              :string           default("")
-#  username               :string           default("")
+#  allow_password_change  :boolean          default(FALSE)
+#  remember_created_at    :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  confirmation_sent_at   :datetime
+#  unconfirmed_email      :string
+#  name                   :string
+#  nickname               :string
+#  image                  :string
+#  email                  :string
+#  tokens                 :json
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  provider               :string           default("email"), not null
-#  uid                    :string           default(""), not null
-#  tokens                 :json
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_users_on_uid_and_provider      (uid,provider) UNIQUE
 #
+# rubocop:enable Layout/LineLength
 
 FactoryBot.define do
   factory :user do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,35 +1,38 @@
 # frozen_string_literal: true
 
+# rubocop:disable Layout/LineLength
 # == Schema Information
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string
+#  id                     :bigint           not null, primary key
+#  provider               :string           default("email"), not null
+#  uid                    :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
-#  allow_password_change  :boolean          default(FALSE), not null
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
-#  first_name             :string           default("")
-#  last_name              :string           default("")
-#  username               :string           default("")
+#  allow_password_change  :boolean          default(FALSE)
+#  remember_created_at    :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  confirmation_sent_at   :datetime
+#  unconfirmed_email      :string
+#  name                   :string
+#  nickname               :string
+#  image                  :string
+#  email                  :string
+#  tokens                 :json
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  provider               :string           default("email"), not null
-#  uid                    :string           default(""), not null
-#  tokens                 :json
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_users_on_uid_and_provider      (uid,provider) UNIQUE
 #
+# rubocop:enable Layout/LineLength
 
 describe User do
   describe 'validations' do


### PR DESCRIPTION
#### Board:
-
---
#### Description:

Rubocop will complain if Annotate adds a line that is too long and it will break CI. To fix this I'm making annotate disable Layout/LineLength for its comments.

---
#### Notes:
*
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:
