### PR TITLE
Config ActiveStorage Current without using concern

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@
 
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
-  include ActiveStorage::SetCurrent
 
   after_action :verify_authorized,
                except: :index,

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,9 +1,9 @@
 local:
-  service: Disk
+  service: DiskWithHost
   root: <%= Rails.root.join('storage') %>
 
 test:
-  service: Disk
+  service: DiskWithHost
   root: <%= Rails.root.join('tmp/storage') %>
 
 amazon:

--- a/lib/active_storage/service/disk_with_host_service.rb
+++ b/lib/active_storage/service/disk_with_host_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'active_storage/service/disk_service'
+
+module ActiveStorage
+  class Service
+    class DiskWithHostService < ActiveStorage::Service::DiskService
+      def url_options
+        Rails.application.default_url_options
+      end
+    end
+  end
+end

--- a/lib/active_storage/service/disk_with_host_service.rb
+++ b/lib/active_storage/service/disk_with_host_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_storage/service/disk_service'
-
 module ActiveStorage
   class Service
     class DiskWithHostService < ActiveStorage::Service::DiskService

--- a/lib/active_storage/service/disk_with_host_service.rb
+++ b/lib/active_storage/service/disk_with_host_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_storage/service/disk_service'
+
 module ActiveStorage
   class Service
     class DiskWithHostService < ActiveStorage::Service::DiskService

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,11 +82,6 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-Rails.application.executor.to_complete do
-  ActiveStorage::Current.url_options = { host: ENV.fetch('SERVER_HOST', nil),
-                                         port: ENV.fetch('PORT', 3000) }
-end
-
 Flipper.configure do |config|
   config.default { Flipper.new(Flipper::Adapters::Memory.new) }
 end


### PR DESCRIPTION
#### Board:
* [Ticket #NUMBER_OF_THE_TICKET](link_goes_here)
---
#### Description:
This PR is for having the fix for the issue when using Active Storage Disk Service in development and test environments but without using the `ActiveStorage::SetCurrent` concern. Also this fix applies now for `APIController`. 

This solution was seen here https://github.com/rails/rails/issues/40855#issuecomment-1970876302

---
#### Notes:
*
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:
