### PR TITLE
Fix Docker usage

### DIFF
--- a/bin/helpers.rb
+++ b/bin/helpers.rb
@@ -7,9 +7,13 @@ rescue StandardError, LoadError => e
 end
 
 def running_with_docker?
-  ENV['DOCKER_ENABLED'] == 'true' && docker_compose_installed?
+  ENV['DOCKER_ENABLED'] == 'true' && docker_compose_installed? && docker_running?
 end
 
 def docker_compose_installed?
   system('which docker-compose > /dev/null 2>&1')
+end
+
+def docker_running?
+  system('docker ps > /dev/null 2>&1')
 end


### PR DESCRIPTION
Now, if `Docker` is off, rails commands will still work. Fixes #753 