### PR TITLE
Fix missing assets when running specs and add link to docs

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -39,6 +39,8 @@ RUN bundle install -j 4
 
 COPY --link . .
 
+RUN yarn build
+
 # Entrypoint prepares the database.
 ENTRYPOINT ["./bin/docker-entrypoint"]
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This template comes with:
 1. (Optional) Run the tests to make sure everything is working with: `bin/rspec .`.
 1. You can now try your REST services!
 
+See [Docker docs](./docs/docker.md) for more info
+
 ## Dev scripts
 
 This template provides a handful of scripts to make your dev experience better!


### PR DESCRIPTION
#### Board:
* [Ticket #NUMBER_OF_THE_TICKET](link_goes_here)
---
#### Description:
- There is this error when running `bin/rspec .`:
```
     Failure/Error: raise AssetNotFound, message unless unknown_asset_fallback

     ActionView::Template::Error:
       The asset "active_admin.js" is not present in the asset pipeline.
```
- This is fixed by adding the `RUN yarn build`
- Also added a link to the docker docs in the readme
---
#### Notes:
*
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:
