### PR TITLE
Add missing platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,6 +330,7 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.7)
     minitest (5.24.1)
     msgpack (1.7.2)
     mutex_m (0.2.0)
@@ -346,6 +347,11 @@ GEM
       net-protocol
     newrelic_rpm (9.11.0)
     nio4r (2.7.3)
+    nokogiri (1.16.6)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.6-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     octokit (9.1.0)
@@ -596,6 +602,8 @@ GEM
     zeitwerk (2.6.16)
 
 PLATFORMS
+  arm64-darwin-22
+  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Dependabot's [PR](https://github.com/rootstrap/rails_api_base/pull/770) removed the Ruby platform. This change causes differences in our Gemfile.lock when installing gems locally in a non-linux architecture