### PR TITLE
Fix fullstack script and Rails generators with Docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,7 +20,6 @@ COPY --from=node /opt /opt
 ENV WORK_ROOT /src
 ENV APP_HOME $WORK_ROOT/app/
 ENV LANG C.UTF-8
-ENV BUNDLE_PATH $WORK_ROOT/bundle
 
 # Create app directory.
 RUN mkdir -p $APP_HOME

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -5,7 +5,7 @@ if ([ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]) || [ "${1}" == "./bin
   ./bin/rails db:prepare
 fi
 
-if [ "${1}" == "./bin/rspec" ]; then
+if [ "${1}" == "./bin/rspec" ] || [ $RAILS_ENV == "test" ]; then
   ./bin/rails db:test:prepare
 fi
 

--- a/bin/fullstack.rb
+++ b/bin/fullstack.rb
@@ -178,6 +178,7 @@ run "bundle exec rubocop -A ."
 
 # Precompile assets
 rails_command "assets:precompile"
+run "yarn build"
 
 # Run tests
 run "bundle exec rspec spec/components/example/component_spec.rb"

--- a/bin/web
+++ b/bin/web
@@ -6,7 +6,7 @@ require_relative 'helpers'
 command = if running_with_docker?
   puts "Running in service web...\n"
 
-  "docker compose run --service-ports web sh -c #{Shellwords.join(ARGV)}"
+  "docker compose run --service-ports --build --rm web sh -c #{Shellwords.join(ARGV)}"
 else
   args = ARGV.length > 1 ? Shellwords.join(ARGV) : ARGV.first
   # we remove '' if the command has it

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,6 +17,7 @@ services:
       SELENIUM_BROWSER: remote
       SELENIUM_BROWSER_HOST: http://chrome-server:4444
       HEADLESS: true
+      RAILS_ENV: test
     tty: true
     stdin_open: true
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,15 +11,8 @@ services:
       BINDING: 0.0.0.0
     tty: true
     stdin_open: true
-    develop:
-      watch:
-        - action: sync
-          path: .
-          target: /src/app
-        - action: rebuild
-          path: package.json
-        - action: rebuild
-          path: Gemfile
+    volumes:
+      - .:/src/app
     depends_on:
       - db
     links:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -10,7 +10,7 @@ Our scripts in `bin` directory have been updated so we can run them with docker.
 `Dockerfile` - This Dockerfile is optimized to run in production environments. It ensures a minimal image size to run the app, by installing the minimal needed dependencies, and also adds Jemalloc to improve the Ruby memory management.
 
 ## Intro to Docker Compose
-`docker-compose.yml` - This compose file is intended to be used only for local development, NOT FOR PRODUCTION. It runs all the services we need in order to run our Rails server, and can be easily extended to include more services if your app needs to. It depends on the `Dockerfile.dev` file and has some "watch" mechanisms to build or reload the app when files change.
+`docker-compose.yml` - This compose file is intended to be used only for local development, NOT FOR PRODUCTION. It runs all the services we need in order to run our Rails server, and can be easily extended to include more services if your app needs to. It depends on the `Dockerfile.dev` file and has a bind mount volume so we can make use of the Rails live-reloading mechanism.
 
 `docker-compose.test.yml` - This compose file is only used for the test environment since it includes a standalone chrome-server service we need to run our E2E tests.
 
@@ -45,10 +45,10 @@ docker compose build
 
 ### How to run
 ```bash
-docker compose up --watch
+docker compose up
 ```
 > [!TIP]
-> You can run `docker compose up --build --watch` if you want to build and run the services in a single step. The watch flag allows to refresh the container content without having to rebuild/restart it manually.
+> You can run `docker compose up --build` if you want to build and run the services in a single step.
 
 ### How to run the tests
 ```bash

--- a/docs/fullstack.md
+++ b/docs/fullstack.md
@@ -14,3 +14,9 @@ In order to setup the `rails_api_base` for fullstack development, run
 bin/rails app:template LOCATION=./bin/fullstack.rb
 ```
 in the root of the project and it will automatically install and configure everything you need.
+
+## Setup with Docker
+If you want to use Docker and also want the example component to be created, you'll need to run this command so the RSpec test passes.
+```bash
+docker compose -f docker-compose.test.yml run --build web ./bin/rails app:template LOCATION=./bin/fullstack.rb
+```


### PR DESCRIPTION
- Remove the `BUNDLE_PATH` env variable from `Dockerfile.dev`. This variable was changing the path where bundler is installing the gems and slowing the volume mount Docker process. Also generating some conflicts with the `fullstack.rb` script and gems were installed twice, in different locations.
- Update the entrypoint script so it runs the `db:test:prepare` command when `RAILS_ENV=true`
- Replace the Docker Compose watch feature with a bind mount volume so Rails generators and scripts are able to create files on the host
    - The watch mechanism does nothing if the path it is watching is already included in a volume. `WARN[0064] path 'Gemfile' also declared by a bind mount volume, this path won't be monitored! `