### PR TITLE
Impersonation prevent the redirect when admin session expired

### DIFF
--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 module Admin
-  class UserPolicy < Admin::ApplicationPolicy; end
+  class UserPolicy < Admin::ApplicationPolicy
+    def impersonate?
+      create? && Flipper.enabled?(:impersonation_tool)
+    end
+  end
 end

--- a/spec/policies/admin/user_policy_spec.rb
+++ b/spec/policies/admin/user_policy_spec.rb
@@ -11,4 +11,21 @@ describe Admin::UserPolicy do
       expect(subject).to permit(admin, user)
     end
   end
+
+  permissions :impersonate? do
+    let(:admin) { create(:admin_user) }
+    let(:user)  { create(:user) }
+
+    it 'allow access when impersonate_tool is enable' do
+      allow(Flipper).to receive(:enabled?).with(:impersonation_tool).and_return(true)
+
+      expect(subject).to permit(admin, user)
+    end
+
+    it 'denies access when impersonate_tool is disable' do
+      allow(Flipper).to receive(:enabled?).with(:impersonation_tool).and_return(false)
+
+      expect(subject).not_to permit(admin, user)
+    end
+  end
 end


### PR DESCRIPTION
#### Description:
Prevent the error when the admin user still in the show page and doing click in the impersonate button

---
#### Notes:
*
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
* LOW
---
#### Preview:
