### PR TITLE
Fix race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
+      - name: Let Rails generate the secret_key_base
+        run: bundle exec rails runner 'puts Rails.application.secret_key_base'
       - name: Setup Database
         run: bundle exec rails parallel:load_schema
       - name: Run yarn commands


### PR DESCRIPTION
We currently have an intermittency in the CI https://github.com/rootstrap/rails_api_base/actions/runs/11445963325/job/31844133037#step:10:18 that seems to be caused by a race condition when generating the secret key base in test env. What Rails does it create a txt file with the value, but our first command that triggers it is the setup of our databases in parallel.

With this PR we make sure that the secret is generated only once, and then it will be used by all the processes running in parallel.