### PR TITLE
Colorize logs in dev

### DIFF
--- a/config/initializers/colorized_logger.rb
+++ b/config/initializers/colorized_logger.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# This initializer adds color to the Rails logger output. It's a nice way to
+# visually distinguish log levels.
+module ColorizedLogger
+  COLOR_CODES = {
+    debug:   "\e[36m",  # Cyan
+    info:    "\e[32m",  # Green
+    warn:    "\e[33m",  # Yellow
+    error:   "\e[31m",  # Red
+    fatal:   "\e[35m",  # Magenta
+    unknown: "\e[37m"   # White (or terminal default)
+  }.freeze
+
+  RESET = "\e[0m"
+
+  def debug(progname = nil, &block)
+    super(colorize(:debug, progname, &block))
+  end
+
+  def info(progname = nil, &block)
+    super(colorize(:info, progname, &block))
+  end
+
+  def warn(progname = nil, &block)
+    super(colorize(:warn, progname, &block))
+  end
+
+  def error(progname = nil, &block)
+    super(colorize(:error, progname, &block))
+  end
+
+  def fatal(progname = nil, &block)
+    super(colorize(:fatal, progname, &block))
+  end
+
+  def unknown(progname = nil, &block)
+    super(colorize(:unknown, progname, &block))
+  end
+
+  private
+
+  def colorize(level, message, &block)
+    "#{COLOR_CODES[level]}#{message || (block && block.call)}#{RESET}"
+  end
+end
+
+Rails.logger.extend(ColorizedLogger)

--- a/config/initializers/colorized_logger.rb
+++ b/config/initializers/colorized_logger.rb
@@ -4,44 +4,44 @@
 # visually distinguish log levels.
 module ColorizedLogger
   COLOR_CODES = {
-    debug:   "\e[36m",  # Cyan
-    info:    "\e[32m",  # Green
-    warn:    "\e[33m",  # Yellow
-    error:   "\e[31m",  # Red
-    fatal:   "\e[35m",  # Magenta
-    unknown: "\e[37m"   # White (or terminal default)
+    debug: "\e[36m", # Cyan
+    info: "\e[32m",  # Green
+    warn: "\e[33m",  # Yellow
+    error: "\e[31m",  # Red
+    fatal: "\e[35m",  # Magenta
+    unknown: "\e[37m" # White (or terminal default)
   }.freeze
 
   RESET = "\e[0m"
 
-  def debug(progname = nil, &block)
-    super(colorize(:debug, progname, &block))
+  def debug(progname = nil, &)
+    super(colorize(:debug, progname, &))
   end
 
-  def info(progname = nil, &block)
-    super(colorize(:info, progname, &block))
+  def info(progname = nil, &)
+    super(colorize(:info, progname, &))
   end
 
-  def warn(progname = nil, &block)
-    super(colorize(:warn, progname, &block))
+  def warn(progname = nil, &)
+    super(colorize(:warn, progname, &))
   end
 
-  def error(progname = nil, &block)
-    super(colorize(:error, progname, &block))
+  def error(progname = nil, &)
+    super(colorize(:error, progname, &))
   end
 
-  def fatal(progname = nil, &block)
-    super(colorize(:fatal, progname, &block))
+  def fatal(progname = nil, &)
+    super(colorize(:fatal, progname, &))
   end
 
-  def unknown(progname = nil, &block)
-    super(colorize(:unknown, progname, &block))
+  def unknown(progname = nil, &)
+    super(colorize(:unknown, progname, &))
   end
 
   private
 
   def colorize(level, message, &block)
-    "#{COLOR_CODES[level]}#{message || (block && block.call)}#{RESET}"
+    "#{COLOR_CODES[level]}#{message || block&.call}#{RESET}"
   end
 end
 

--- a/config/initializers/colorized_logger.rb
+++ b/config/initializers/colorized_logger.rb
@@ -1,48 +1,50 @@
 # frozen_string_literal: true
 
-# This initializer adds color to the Rails logger output. It's a nice way to
-# visually distinguish log levels.
-module ColorizedLogger
-  COLOR_CODES = {
-    debug: "\e[36m", # Cyan
-    info: "\e[32m",  # Green
-    warn: "\e[33m",  # Yellow
-    error: "\e[31m",  # Red
-    fatal: "\e[35m",  # Magenta
-    unknown: "\e[37m" # White (or terminal default)
-  }.freeze
+if Rails.env.local?
+  # This initializer adds color to the Rails logger output. It's a nice way to
+  # visually distinguish log levels.
+  module ColorizedLogger
+    COLOR_CODES = {
+      debug: "\e[36m", # Cyan
+      info: "\e[32m",  # Green
+      warn: "\e[33m",  # Yellow
+      error: "\e[31m",  # Red
+      fatal: "\e[35m",  # Magenta
+      unknown: "\e[37m" # White (or terminal default)
+    }.freeze
 
-  RESET = "\e[0m"
+    RESET = "\e[0m"
 
-  def debug(progname = nil, &)
-    super(colorize(:debug, progname, &))
+    def debug(progname = nil, &)
+      super(colorize(:debug, progname, &))
+    end
+
+    def info(progname = nil, &)
+      super(colorize(:info, progname, &))
+    end
+
+    def warn(progname = nil, &)
+      super(colorize(:warn, progname, &))
+    end
+
+    def error(progname = nil, &)
+      super(colorize(:error, progname, &))
+    end
+
+    def fatal(progname = nil, &)
+      super(colorize(:fatal, progname, &))
+    end
+
+    def unknown(progname = nil, &)
+      super(colorize(:unknown, progname, &))
+    end
+
+    private
+
+    def colorize(level, message, &block)
+      "#{COLOR_CODES[level]}#{message || block&.call}#{RESET}"
+    end
   end
 
-  def info(progname = nil, &)
-    super(colorize(:info, progname, &))
-  end
-
-  def warn(progname = nil, &)
-    super(colorize(:warn, progname, &))
-  end
-
-  def error(progname = nil, &)
-    super(colorize(:error, progname, &))
-  end
-
-  def fatal(progname = nil, &)
-    super(colorize(:fatal, progname, &))
-  end
-
-  def unknown(progname = nil, &)
-    super(colorize(:unknown, progname, &))
-  end
-
-  private
-
-  def colorize(level, message, &block)
-    "#{COLOR_CODES[level]}#{message || block&.call}#{RESET}"
-  end
+  Rails.logger.extend(ColorizedLogger)
 end
-
-Rails.logger.extend(ColorizedLogger)

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
-  config.lograge.enabled = true
+  config.lograge.enabled = Rails.env.production?
   config.lograge.base_controller_class = ['ActionController::API', 'ActionController::Base']
   config.lograge.custom_payload do |controller|
     request = controller.request


### PR DESCRIPTION
Taken from https://gist.github.com/kyrylo/3d90f7a656d1a0accf244b8f1d25999b

Improves logs legibility by colorizing them by the log level

Another additional gem that may be worth adding (but requires more manual setup) is https://github.com/mechanicles/colorize_logs

BEFORE:
![image](https://github.com/user-attachments/assets/9091c888-b3e0-4cca-a526-f576f65c9906)

AFTER:
![image](https://github.com/user-attachments/assets/07dab1d0-4772-40de-99bb-e01b67ee5edf)
