### PR TITLE
Fix Docker entrypoint syntax error

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -5,7 +5,7 @@ if ([ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]) || [ "${1}" == "./bin
   ./bin/rails db:prepare
 fi
 
-if [ "${1}" == "./bin/rspec" ] || [ $RAILS_ENV == "test" ]; then
+if [ "${1}" == "./bin/rspec" ] || [ "${RAILS_ENV}" == "test" ]; then
   ./bin/rails db:test:prepare
 fi
 


### PR DESCRIPTION
When running commands with Docker, I noticed the following error
```
./bin/docker-entrypoint: line 8: [: ==: unary operator expected
```

This PR fixes the syntax error in the shell script.