### PR TITLE
Disable logging in CI

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -70,4 +70,10 @@ Rails.application.configure do
 
   # Use test adapter for ActiveJob
   config.active_job.queue_adapter = :test
+
+  # Disable logging in CI to improve run time by 10%
+  if ENV['CI'].present?
+    config.logger = Logger.new(nil)
+    config.log_level = :fatal
+  end
 end


### PR DESCRIPTION
https://x.com/fatkodima/status/1748058608535756914

Tested in a real repo:

BEFORE
```
4402 examples, 23 failures, 1 pending

Took 160 seconds (2:40)
Tests Failed
bundle exec parallel_rspec  613.98s user 63.37s system 420% cpu 2:41.04 total
```

AFTER
```
4402 examples, 28 failures, 1 pending

Took 142 seconds (2:22)
Tests Failed
bundle exec parallel_rspec  545.65s user 46.75s system 414% cpu 2:23.01 total
```