### PR TITLE
Fix icons not displayed in ActiveAdmin

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -6,10 +6,12 @@
 //
 // For example, to change the sidebar width:
 // $sidebar-width: 242px;
+$fa-font-path: ".";
 
 // Active Admin's got SASS!
 @import 'arctic_admin/src/scss/main';
-@import '@fortawesome/fontawesome-free/css/all.css';
+@import '@fortawesome/fontawesome-free/scss/fontawesome.scss';
+@import '@fortawesome/fontawesome-free/scss/solid.scss';
 
 // Overriding any non-variable Sass must be done after the fact.
 // For example, to change the default status-tag color:

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,8 +9,9 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join('node_modules/@fortawesome/fontawesome-free/webfonts')
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w[active_admin.js active_admin.css]
+Rails.application.config.assets.precompile += %w[active_admin.js active_admin.css *.ttf *.woff2]


### PR DESCRIPTION
#### Board:
* [Ticket #NUMBER_OF_THE_TICKET](link_goes_here)
---
#### Description:
<!-- * Add a description of what is the aim of this PR -->
- Icons were not displayed in Active Admin.
---
#### Notes:
*
---
#### Tasks:
- [x] Update `app/assets/stylesheets/active_admin.scss` and `config/initializers/assets.rb` files.
---
#### Risk:
*
---
#### Preview:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/0870f089-2ef1-4224-8c96-2ba88408ea9c" />

