### PR TITLE
Improve Docker CI Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,31 +27,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ github.head_ref || github.ref_name }}
-            ${{ runner.os }}-buildx-main
-            ${{ runner.os }}-buildx-
-
       - name: Build prod Docker image
         uses: docker/build-push-action@v6
         with:
           push: false
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: |
+            type=gha,scope=${{ github.ref_name }}
+            type=gha,ref=main
+          cache-to: type=gha,scope=${{ github.ref_name }},mode=max
           file: Dockerfile
-
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   linters:
     name: Linters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,10 @@
 name: CI
 
 on:
+  workflow_dispatch:
+  pull_request:
   push:
-# on:
-#   workflow_dispatch:
-#   pull_request:
-#   push:
-#     branches: [main]
+    branches: [main]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
 on:
-  workflow_dispatch:
-  pull_request:
   push:
-    branches: [main]
+# on:
+#   workflow_dispatch:
+#   pull_request:
+#   push:
+#     branches: [main]
 
 permissions:
   pull-requests: write

--- a/app/controllers/api/v1/health_controller.rb
+++ b/app/controllers/api/v1/health_controller.rb
@@ -7,7 +7,7 @@ module API
       skip_after_action :verify_authorized
 
       def status
-        render json: { online: true }
+        render json: { online: true, test: true }
       end
     end
   end

--- a/app/controllers/api/v1/health_controller.rb
+++ b/app/controllers/api/v1/health_controller.rb
@@ -7,7 +7,7 @@ module API
       skip_after_action :verify_authorized
 
       def status
-        render json: { online: true, test: true }
+        render json: { online: true }
       end
     end
   end


### PR DESCRIPTION
#### Board:
* [Ticket #NUMBER_OF_THE_TICKET](link_goes_here)
---
#### Description:
Changes Docker image caching in CI to use GHA Cache. This reduces build time by ~20 seconds if cached image exists (tested with only code changes). Additionally, this already handles compression, reducing the size of cache entries.

You can check the cache entries generated for this PR (last two commits) [here](https://github.com/rootstrap/rails_api_base/actions/caches?page=2&query=branch%3Arefs%2Fpull%2F960%2Fmerge).

---
#### Notes:
*
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:
