### PR TITLE
Use release script when deploying with containers

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-bundle exec rails db:migrate
-bundle exec rails feature_flags:initialize
+echo "Running release script" &&
+  bundle exec rails feature_flags:initialize

--- a/heroku.yml
+++ b/heroku.yml
@@ -11,3 +11,7 @@ run:
     command:
       - bundle exec rails jobs:work
     image: web
+release:
+  image: web
+  command:
+    - ./bin/release.sh


### PR DESCRIPTION
#### Description:
When using the `heroku.yml` to deploy apps with the container stack on Heroku, the release script is not being executed. This PR fixes the issue by adding the script into the `heroku.yml` file.

Note: Migrations are executed as part of the `docker-entrypoint` script, so we don't need to run them during the release phase (just like Rails does in [this template](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt#L12))