### PR TITLE
Use PORT ENV VAR instead of hardcoding it

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: ./bin/rails server -p 3000 -b 0.0.0.0
+web: ./bin/rails server -b 0.0.0.0
 js: yarn build:js --watch
 css: yarn build:css --watch


### PR DESCRIPTION
Without this change, the PORT ENV VAR is not respected when running `bin/dev`