### PR TITLE
Add missing bundler require in setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 require 'fileutils'
+require_relative 'bundler'
+
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
 


### PR DESCRIPTION
#### Board:
* [No Ticket #NUMBER_OF_THE_TICKET](link_goes_here)
---
#### Description:
* Add missing bundle require

```
Replacement completed successfully.
== Installing dependencies ==
bin/setup:16:in 'block in <main>': undefined local variable or method 'bundler_version' for main (NameError)

  system! "bin/web 'gem install bundler -v '#{bundler_version}''"
```
---
#### Notes:
*
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:
