### PR TITLE
Fix ActiveAdmin missing icons

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -6,12 +6,14 @@
 //
 // For example, to change the sidebar width:
 // $sidebar-width: 242px;
-$fa-font-path: ".";
+@use '@fortawesome/fontawesome-free/scss/variables' with ($font-path: ".");
+@use '@fortawesome/fontawesome-free/scss/fontawesome';
+@use '@fortawesome/fontawesome-free/scss/solid';
+
+$font-icon: 'Font Awesome 7 Free';
 
 // Active Admin's got SASS!
 @import 'arctic_admin/src/scss/main';
-@import '@fortawesome/fontawesome-free/scss/fontawesome.scss';
-@import '@fortawesome/fontawesome-free/scss/solid.scss';
 
 // Overriding any non-variable Sass must be done after the fact.
 // For example, to change the default status-tag color:


### PR DESCRIPTION
### Fix ActiveAdmin icons with Font Awesome 7

#### Description:

After bumping `@fortawesome/fontawesome-free` to 7.x, icons in the ActiveAdmin UI render as empty squares. The issue is `arctic_admin`'s `_icons.scss` still defaults `$font-icon` to `'Font Awesome 6 Free', 'Font Awesome 6 Pro'`. With Font Awesome 7 installed, the `@font-face` registers `"Font Awesome 7 Free"`, so arctic_admin's `font:` declarations fall back to a font the browser doesn't have.

#### Fix:
In `app/assets/stylesheets/active_admin.scss`:

- Replace the FA `@import`s with `@use … with ($font-path: ".")` so the override actually propagates through FA7's module system.
- Keep the `$font-icon: 'Font Awesome 7 Free';` top-level override for arctic_admin, which still uses `@import` internally and picks up `!default` overrides the old way.

---
#### Preview:

##### Before
- Chrome:
<img width="1172" height="421" alt="Screenshot 2026-05-11 at 11 24 09 AM" src="https://github.com/user-attachments/assets/d9a38bb8-740b-46a2-9f8e-08b485d788ee" />


- Firefox:
<img width="1202" height="450" alt="Screenshot 2026-05-11 at 12 02 49 PM" src="https://github.com/user-attachments/assets/47fcec49-ee1a-40f4-a3c5-073899aafcc3" />



##### After
<img width="1172" height="448" alt="Screenshot 2026-05-11 at 11 25 04 AM" src="https://github.com/user-attachments/assets/fc8097f2-147d-42cd-b4a6-2298a34743f4" />