### PR TITLE
fix: skip secret-dependent CI steps for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           echo "SONAR_PROJECT_VERSION=$(echo $GITHUB_SHA | cut -c1-8)" >> $GITHUB_ENV
           echo "SONAR_REPORT_PATHS=$(ls coverage/coverage-*.json | paste -sd "," -)" >> $GITHUB_ENV
       - name: SonarQube Scanner
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: sonarsource/sonarqube-scan-action@v8.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -224,7 +225,7 @@ jobs:
         if: ${{ env.OPENAPI }}
         run: bundle exec ./bin/merge-api-docs.rb
       - name: Commit & push API Docs
-        if: ${{ env.OPENAPI }}
+        if: ${{ env.OPENAPI }} && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"


### PR DESCRIPTION
## Problem

CI fails on PRs coming from forks. GitHub does not expose repository secrets to fork PRs for security reasons, so any step depending on secrets fails.

Validated by opening a test fork PR ([#1410](https://github.com/rootstrap/rails_api_base/pull/1410)) — `Merge Results` job failed immediately at `SonarQube Scanner` because `SONAR_TOKEN` and `SONAR_HOST_URL` were empty.

Related task: https://app.notion.com/p/e4411b2f2b8b4a0e87f1f9a1d5cf315a

## Root cause

Two steps in `merge_results` job are incompatible with fork PRs:

- **SonarQube Scanner** — requires `SONAR_TOKEN` + `SONAR_HOST_URL` (unavailable in forks)
- **Commit & push API Docs** — requires write access via `PUSH_KEY` (unavailable in forks)

## Fix

Add an `if` condition to both steps to skip them when the PR originates from a fork:

```
github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

This keeps full CI behavior for PRs from within the repo while gracefully skipping secret-dependent steps for external contributors.

## Test plan

- [ ] Open a fork PR and verify `Merge Results` passes (SonarQube skipped)
- [ ] Open an internal PR and verify SonarQube still runs normally